### PR TITLE
chore: remove tracked env files and clean history

### DIFF
--- a/docs/handoffs/handoff-cc-hmcp-000001g.md
+++ b/docs/handoffs/handoff-cc-hmcp-000001g.md
@@ -1,0 +1,43 @@
+# Handoff — CC-HMCP-000001G
+
+**Date:** 2026-03-31  
+**Prompt:** CC-HMCP-000001G  
+**Branch:** feature/cc-hmcp-000001g-env-cleanup  
+
+---
+
+## What Was Checked
+
+1. Current index — `git ls-files` filtered for `.env`, `.env.*`, `*.env` patterns
+2. Full repository history — `git log --all --full-history` against env file patterns
+3. All filenames ever committed — `git log --all --name-only` scanned for env-pattern matches
+
+---
+
+## What Was Found
+
+**No tracked environment files found — in current index or in repository history.**
+
+The repository has never committed a `.env`, `.env.*`, or `*.env` file. The `.gitignore` introduced in CC-HMCP-000001E was added before any environment files were created or tracked.
+
+---
+
+## Actions Taken
+
+- No files removed from tracking (none were tracked)
+- No history rewrite required
+- No force-push required
+
+---
+
+## Secret Rotation Recommendation
+
+**Not required.** No secret-bearing environment files were found in repository history. No exposure occurred.
+
+---
+
+## PR Handling
+
+This branch contains only this remediation note. It is a straightforward PR with no history rewrite and no special downstream coordination required.
+
+---


### PR DESCRIPTION
Notes
- No tracked env files found in current index or Git history
- No history rewrite performed
- No force-push required
- Secret rotation: not required — no exposure occurred