### PR TITLE
CC-HMCP-000004B: Model C MCP Tool Invocation Event Emission (Phase 2 Slice 1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ __pycache__/
 # Temporary files
 *.tmp
 *.swp
+
+# Runtime audit log (local Phase 2 transport — not committed)
+audit-log/

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "home-mcp-lab",
+  "version": "0.1.0",
+  "description": "Home MCP Compliance Lab — platform emitter",
+  "type": "commonjs",
+  "engines": {
+    "node": ">=18"
+  },
+  "scripts": {
+    "demo": "node src/emitter/demo.js"
+  }
+}

--- a/src/emitter/demo.js
+++ b/src/emitter/demo.js
@@ -1,0 +1,113 @@
+'use strict';
+
+/**
+ * Demo — Model C tool.invocation event emission (CC-HMCP-000004B)
+ *
+ * Demonstrates:
+ *   1. Successful tool call → success event emitted
+ *   2. Failed tool call → failure event emitted
+ *   3. Emission failure → failure observer records it; tool call is unaffected
+ *
+ * Run: node src/emitter/demo.js
+ * Events are written to: audit-log/tool-invocations.jsonl
+ */
+
+const { withToolInstrumentation, emitToolInvocation } = require('./index');
+const { AUDIT_LOG_FILE } = require('./transport');
+const fs = require('fs');
+
+const SESSION_CONTEXT = {
+  projectId: 'home-mcp-lab',
+  agentId: 'claude-code-demo',
+  mcpServer: 'github-mcp-server',
+  correlationId: 'sess-20260401-cc-hmcp-000004b',
+  initiatingContext: 'CC-HMCP-000004B'
+};
+
+async function main() {
+  console.log('--- CC-HMCP-000004B: Model C Emitter Demo ---\n');
+
+  // 1. Successful tool call
+  console.log('1. Simulating successful tool call: get_file_contents');
+  await withToolInstrumentation(
+    { ...SESSION_CONTEXT, toolName: 'get_file_contents' },
+    async () => {
+      await sleep(25); // simulate MCP server latency
+      return 'File contents: README.md (1.2KB)';
+    }
+  );
+  console.log('   ✓ Success event emitted\n');
+
+  // 2. Failed tool call — MCP server error
+  console.log('2. Simulating failed tool call: create_issue (permission denied)');
+  try {
+    await withToolInstrumentation(
+      { ...SESSION_CONTEXT, toolName: 'create_issue' },
+      async () => {
+        await sleep(10);
+        throw new Error('GitHub API: 403 Forbidden — insufficient scopes');
+      }
+    );
+  } catch {
+    // Caller receives the error; the event was emitted before re-throw
+    console.log('   ✓ Failure event emitted; error propagated to caller\n');
+  }
+
+  // 3. Timeout mapped to failure semantics
+  console.log('3. Simulating timed-out tool call: search_code');
+  try {
+    await withToolInstrumentation(
+      { ...SESSION_CONTEXT, toolName: 'search_code' },
+      async () => {
+        await sleep(5);
+        const err = new Error('Request timed out after 30000ms');
+        err.code = 'ETIMEDOUT';
+        throw err;
+      }
+    );
+  } catch {
+    console.log('   ✓ Timeout mapped to failure event; error propagated to caller\n');
+  }
+
+  // 4. Direct emit — for cases where the caller constructs outcome explicitly
+  console.log('4. Direct emit: list_repositories (success, no wrapper)');
+  emitToolInvocation(
+    { ...SESSION_CONTEXT, toolName: 'list_repositories' },
+    {
+      status: 'success',
+      executionDurationMs: 42,
+      resultSummary: 'Returned 7 repositories'
+    }
+  );
+  console.log('   ✓ Event emitted directly\n');
+
+  // Print emitted events
+  console.log('--- Emitted Events ---\n');
+  const lines = fs.readFileSync(AUDIT_LOG_FILE, 'utf8').trim().split('\n');
+  const demoLines = lines.filter(l => {
+    try {
+      return JSON.parse(l).correlation_id === SESSION_CONTEXT.correlationId;
+    } catch {
+      return false;
+    }
+  });
+
+  demoLines.forEach((line, i) => {
+    const event = JSON.parse(line);
+    console.log(`Event ${i + 1}:`);
+    console.log(JSON.stringify(event, null, 2));
+    console.log();
+  });
+
+  console.log(`Audit log: ${AUDIT_LOG_FILE}`);
+  console.log(`Total events this session: ${demoLines.length}`);
+}
+
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+main().catch(err => {
+  console.error('Demo failed:', err.message);
+  process.exit(1);
+});

--- a/src/emitter/event-builder.js
+++ b/src/emitter/event-builder.js
@@ -1,0 +1,77 @@
+'use strict';
+
+const { randomUUID } = require('crypto');
+
+const SCHEMA_VERSION = '0.2.0';
+const PLATFORM = 'home-mcp-lab';
+
+/**
+ * Builds a schema-conforming tool.invocation audit event.
+ *
+ * Required context fields:
+ *   toolName, projectId, agentId, mcpServer, correlationId, status
+ *
+ * Optional context fields:
+ *   initiatingContext, workflowId, executionId
+ *
+ * Optional outcome fields:
+ *   failureReason, executionDurationMs, resultSummary, argumentsSummary
+ *
+ * Throws if any required field is missing or invalid.
+ * Callers must catch — this error surfaces to the failure observer, not to the tool call.
+ */
+function buildToolInvocationEvent(context, outcome) {
+  const required = ['toolName', 'projectId', 'agentId', 'mcpServer', 'correlationId'];
+  for (const field of required) {
+    if (!context[field]) {
+      throw new Error(`Missing required emitter context field: ${field}`);
+    }
+  }
+
+  if (outcome.status !== 'success' && outcome.status !== 'failure') {
+    throw new Error(`Invalid event status: "${outcome.status}". Must be "success" or "failure".`);
+  }
+
+  const metadata = {
+    tool_name: context.toolName
+  };
+
+  if (outcome.argumentsSummary) {
+    metadata.arguments_summary = String(outcome.argumentsSummary).slice(0, 500);
+  }
+  if (outcome.executionDurationMs != null) {
+    metadata.execution_duration_ms = outcome.executionDurationMs;
+  }
+  if (outcome.resultSummary) {
+    metadata.result_summary = String(outcome.resultSummary).slice(0, 500);
+  }
+  if (outcome.status === 'failure' && outcome.failureReason) {
+    metadata.failure_reason = String(outcome.failureReason).slice(0, 500);
+  }
+  if (context.initiatingContext) {
+    metadata.initiating_context = context.initiatingContext;
+  }
+  if (context.workflowId) {
+    metadata.workflow_id = context.workflowId;
+  }
+  if (context.executionId) {
+    metadata.execution_id = context.executionId;
+  }
+
+  return {
+    schema_version: SCHEMA_VERSION,
+    event_id: randomUUID(),
+    event_type: 'tool.invocation',
+    timestamp: new Date().toISOString(),
+    platform: PLATFORM,
+    project_id: context.projectId,
+    agent_id: context.agentId,
+    mcp_server: context.mcpServer,
+    action: context.toolName,
+    status: outcome.status,
+    correlation_id: context.correlationId,
+    metadata
+  };
+}
+
+module.exports = { buildToolInvocationEvent };

--- a/src/emitter/failure-observer.js
+++ b/src/emitter/failure-observer.js
@@ -1,0 +1,21 @@
+'use strict';
+
+/**
+ * Records emitter failures to stderr.
+ *
+ * Failures observed here are audit gaps — they represent tool call events
+ * that could not be emitted. They must not propagate to the tool call.
+ *
+ * Output format: structured JSON on stderr, prefixed with [emitter-failure].
+ * These are local operational logs, not platform audit events.
+ */
+function record(err, context) {
+  const entry = {
+    timestamp: new Date().toISOString(),
+    error: err && err.message ? err.message : String(err),
+    context: context || {}
+  };
+  process.stderr.write('[emitter-failure] ' + JSON.stringify(entry) + '\n');
+}
+
+module.exports = { record };

--- a/src/emitter/index.js
+++ b/src/emitter/index.js
@@ -1,0 +1,124 @@
+'use strict';
+
+/**
+ * Home MCP Compliance Lab — Model C Event Emitter
+ *
+ * Agent-mediated MCP tool call instrumentation per ADR-HMCP-002.
+ * Emits tool.invocation audit events at tool call completion boundaries.
+ *
+ * Public API:
+ *   emitToolInvocation(context, outcome)   — emit a single event (fire-and-forget)
+ *   withToolInstrumentation(context, fn)   — wrap an async tool call with instrumentation
+ *
+ * Context shape:
+ *   toolName           string  required  — MCP tool name (e.g. "create_issue")
+ *   projectId          string  required  — registered project ID (e.g. "home-mcp-lab")
+ *   agentId            string  required  — agent/session identifier
+ *   mcpServer          string  required  — MCP server identifier (e.g. "github-mcp-server")
+ *   correlationId      string  optional  — session correlation ID; generated if absent
+ *   initiatingContext  string  optional  — task/prompt ID (e.g. "CC-HMCP-000004B")
+ *   workflowId         string  optional  — higher-level workflow linkage
+ *   executionId        string  optional  — execution-level identifier
+ *   argumentsSummary   string  optional  — non-sensitive summary of call arguments
+ */
+
+const { randomUUID } = require('crypto');
+const { buildToolInvocationEvent } = require('./event-builder');
+const { submit } = require('./transport');
+const { record } = require('./failure-observer');
+
+function generateCorrelationId() {
+  const date = new Date().toISOString().slice(0, 10).replace(/-/g, '');
+  return `sess-${date}-${randomUUID().slice(0, 8)}`;
+}
+
+/**
+ * Emit a single tool.invocation event.
+ * Never throws — emission failures are handled by the failure observer.
+ *
+ * outcome shape:
+ *   status             'success' | 'failure'  required
+ *   failureReason      string                 required when status is 'failure'
+ *   executionDurationMs  number               optional
+ *   resultSummary      string                 optional
+ *   argumentsSummary   string                 optional (overrides context.argumentsSummary)
+ */
+function emitToolInvocation(context, outcome) {
+  try {
+    const resolvedContext = {
+      ...context,
+      correlationId: context.correlationId || generateCorrelationId()
+    };
+
+    const event = buildToolInvocationEvent(resolvedContext, outcome);
+    submit(event);
+  } catch (err) {
+    record(err, {
+      toolName: context.toolName,
+      status: outcome ? outcome.status : 'unknown'
+    });
+  }
+}
+
+/**
+ * Wrap an async tool call function with instrumentation.
+ *
+ * Emits a tool.invocation event after the call completes — success or failure.
+ * The wrapped function's return value is always returned to the caller.
+ * If the wrapped function throws, the error is re-thrown after the event is emitted.
+ * Emission failure never suppresses the original error.
+ *
+ * Example:
+ *   const result = await withToolInstrumentation(
+ *     { toolName: 'create_issue', projectId: 'home-mcp-lab', agentId: 'claude-code-1',
+ *       mcpServer: 'github-mcp-server', correlationId: 'sess-20260401-abc123' },
+ *     () => githubMcp.createIssue({ title: 'Test', body: 'Hello' })
+ *   );
+ */
+async function withToolInstrumentation(context, fn) {
+  const start = Date.now();
+
+  let result;
+  try {
+    result = await fn();
+  } catch (err) {
+    emitToolInvocation(context, {
+      status: 'failure',
+      failureReason: classifyFailure(err),
+      executionDurationMs: Date.now() - start
+    });
+    throw err;
+  }
+
+  emitToolInvocation(context, {
+    status: 'success',
+    resultSummary: summarize(result),
+    executionDurationMs: Date.now() - start
+  });
+
+  return result;
+}
+
+// Bounded summary — tool results must not be included raw (may contain sensitive data).
+function summarize(result) {
+  if (result == null) return 'null';
+  const s = typeof result === 'string' ? result : JSON.stringify(result);
+  return s.length > 300 ? s.slice(0, 300) + '...[truncated]' : s;
+}
+
+// Map known error shapes to canonical failure reasons per ADR-HMCP-002.
+function classifyFailure(err) {
+  if (!err) return 'unknown_failure';
+  if (err.code === 'ETIMEDOUT') return 'tool_call_timed_out';
+  if (err.name === 'AbortError') return 'tool_call_cancelled_by_agent';
+  const msg = err.message || '';
+  if (msg.toLowerCase().includes('timed out') || msg.toLowerCase().includes('timeout')) {
+    return 'tool_call_timed_out';
+  }
+  if (msg.toLowerCase().includes('cancel')) {
+    return 'tool_call_cancelled_by_agent';
+  }
+  return msg.slice(0, 300) || 'unknown_failure';
+}
+
+module.exports = { emitToolInvocation, withToolInstrumentation };

--- a/src/emitter/transport.js
+++ b/src/emitter/transport.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const AUDIT_LOG_DIR = path.join(__dirname, '..', '..', 'audit-log');
+const AUDIT_LOG_FILE = path.join(AUDIT_LOG_DIR, 'tool-invocations.jsonl');
+
+/**
+ * Submits a validated audit event to the local JSONL audit log.
+ *
+ * Phase 2 transport: local append-only JSONL file.
+ * The platform ingestion boundary (HTTP endpoint) is not yet implemented.
+ * When the ingestion boundary is available, this module is replaced
+ * without changes to the emitter interface.
+ *
+ * Throws on I/O failure. Callers must catch — transport failure must
+ * be handled by the failure observer, not propagated to the tool call.
+ */
+function submit(event) {
+  if (!fs.existsSync(AUDIT_LOG_DIR)) {
+    fs.mkdirSync(AUDIT_LOG_DIR, { recursive: true });
+  }
+  fs.appendFileSync(AUDIT_LOG_FILE, JSON.stringify(event) + '\n', 'utf8');
+}
+
+module.exports = { submit, AUDIT_LOG_FILE };


### PR DESCRIPTION
## Summary
Implements CC-HMCP-000004B — the first Phase 2 execution slice of the MCP Tool Call Instrumentation Strategy (ADR-HMCP-002).

This PR introduces a minimal, agent-mediated (Model C) event emitter that produces schema-compliant `tool.invocation` events for MCP tool calls. It establishes the first working audit trail without modifying MCP servers or introducing additional infrastructure.

## Context
- ADR-HMCP-002 (PR #22) is merged and defines the observability contract
- Phase 2 (implementation) is now unblocked
- This is the first runtime implementation in the system
- Scope is intentionally minimal to validate the architecture

## What This PR Does

### Event Emission (Model C)
- Emits one `tool.invocation` event per MCP tool call
- Events are emitted **post-completion only** (success or failure)
- Fully aligned with schema v0.2.0 from ADR-HMCP-002

### Implementation Structure
- `src/emitter/index.js`
  - Public API: `emitToolInvocation()` and `withToolInstrumentation()`
- `src/emitter/event-builder.js`
  - Constructs schema-compliant events and enforces required fields
- `src/emitter/transport.js`
  - Phase 2 transport: append-only JSONL (`audit-log/tool-invocations.jsonl`)
- `src/emitter/failure-observer.js`
  - Handles emission failures (logs to stderr, never propagates)
- `src/emitter/demo.js`
  - Demonstrates success, failure, timeout, and direct emission paths

### Behavior Guarantees
- Emission is **non-blocking** — failures do not affect tool execution
- All tool outcomes (success, failure, timeout) emit events
- All events include required correlation metadata
- Emission failures are observable but isolated