### PR TITLE
Implements CC-HMCP-000004C — Session Lifecycle Instrumentation (Phase 2 Slice 2)

### DIFF
--- a/src/emitter/demo-session.js
+++ b/src/emitter/demo-session.js
@@ -1,0 +1,147 @@
+'use strict';
+
+/**
+ * Demo — Session lifecycle instrumentation (CC-HMCP-000004C)
+ *
+ * Demonstrates:
+ *   1. Successful session — session.start, multiple tool.invocation, session.end
+ *   2. Failed session — session.start, tool failure, session.end (failure)
+ *   3. All events share the same correlation_id within each session
+ *
+ * Run: node src/emitter/demo-session.js
+ * Events are written to: audit-log/tool-invocations.jsonl
+ */
+
+const { withSession, withToolInstrumentation } = require('./index');
+const { AUDIT_LOG_FILE } = require('./transport');
+const fs = require('fs');
+
+const BASE_CONTEXT = {
+  projectId: 'home-mcp-lab',
+  agentId: 'claude-code-demo',
+  mcpServer: 'github-mcp-server',
+  initiatingContext: 'CC-HMCP-000004C'
+};
+
+async function main() {
+  console.log('--- CC-HMCP-000004C: Session Lifecycle Demo ---\n');
+
+  // Record the start of the JSONL log so we can extract only this run's events.
+  const linesBefore = countLines(AUDIT_LOG_FILE);
+
+  // === Scenario 1: Successful multi-step session ===
+  console.log('Scenario 1: Successful session with 3 tool calls');
+  await withSession(BASE_CONTEXT, async (sessionCtx) => {
+    await withToolInstrumentation(
+      { ...sessionCtx, toolName: 'list_repositories' },
+      async () => { await sleep(15); return ['home-mcp-lab', 'erate-workbench']; }
+    );
+    await withToolInstrumentation(
+      { ...sessionCtx, toolName: 'get_file_contents' },
+      async () => { await sleep(10); return 'README.md content (2.1KB)'; }
+    );
+    await withToolInstrumentation(
+      { ...sessionCtx, toolName: 'create_issue' },
+      async () => { await sleep(20); return { id: 42, title: 'Test issue' }; }
+    );
+  });
+  console.log('   ✓ Session completed successfully\n');
+
+  // === Scenario 2: Session containing a failing tool call ===
+  console.log('Scenario 2: Session where a tool call fails mid-session');
+  await withSession(BASE_CONTEXT, async (sessionCtx) => {
+    // First tool succeeds
+    await withToolInstrumentation(
+      { ...sessionCtx, toolName: 'get_file_contents' },
+      async () => { await sleep(10); return 'file content'; }
+    );
+    // Second tool fails — event is emitted, error is re-thrown, session continues
+    try {
+      await withToolInstrumentation(
+        { ...sessionCtx, toolName: 'push_files' },
+        async () => {
+          await sleep(5);
+          throw new Error('GitHub API: 422 Unprocessable Entity — branch is protected');
+        }
+      );
+    } catch {
+      // Session continues after tool failure — handled by caller
+    }
+    // Third tool proceeds after the failure
+    await withToolInstrumentation(
+      { ...sessionCtx, toolName: 'search_code' },
+      async () => { await sleep(8); return '3 results'; }
+    );
+  });
+  console.log('   ✓ Session ended (success) despite one tool failure\n');
+
+  // === Scenario 3: Session-level failure (fn itself throws) ===
+  console.log('Scenario 3: Session-level failure — session.end emits with status:failure');
+  try {
+    await withSession(BASE_CONTEXT, async (sessionCtx) => {
+      await withToolInstrumentation(
+        { ...sessionCtx, toolName: 'get_file_contents' },
+        async () => { await sleep(5); return 'ok'; }
+      );
+      // Uncaught throw — propagates out of withSession
+      throw new Error('Unrecoverable workflow state — aborting session');
+    });
+  } catch {
+    console.log('   ✓ Session ended (failure); error propagated to caller\n');
+  }
+
+  // === Print full session traces ===
+  console.log('--- Emitted Events (this run) ---\n');
+  const allLines = fs.readFileSync(AUDIT_LOG_FILE, 'utf8').trim().split('\n');
+  const thisRunLines = allLines.slice(linesBefore);
+
+  const sessions = groupBySession(thisRunLines);
+
+  for (const [correlationId, events] of Object.entries(sessions)) {
+    console.log(`Session: ${correlationId}`);
+    console.log(`  Events: ${events.length} (${events.map(e => e.event_type).join(' → ')})`);
+    console.log();
+    for (const event of events) {
+      console.log(JSON.stringify(event, null, 2));
+      console.log();
+    }
+    console.log('---\n');
+  }
+
+  console.log(`Audit log: ${AUDIT_LOG_FILE}`);
+  console.log(`Sessions this run: ${Object.keys(sessions).length}`);
+  console.log(`Total events this run: ${thisRunLines.length}`);
+}
+
+function groupBySession(lines) {
+  const sessions = {};
+  for (const line of lines) {
+    if (!line.trim()) continue;
+    try {
+      const event = JSON.parse(line);
+      const id = event.correlation_id || '__no_session__';
+      if (!sessions[id]) sessions[id] = [];
+      sessions[id].push(event);
+    } catch {
+      // skip malformed lines
+    }
+  }
+  return sessions;
+}
+
+function countLines(file) {
+  try {
+    return fs.readFileSync(file, 'utf8').trim().split('\n').length;
+  } catch {
+    return 0;
+  }
+}
+
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+main().catch(err => {
+  console.error('Demo failed:', err.message);
+  process.exit(1);
+});

--- a/src/emitter/event-builder.js
+++ b/src/emitter/event-builder.js
@@ -6,6 +6,106 @@ const SCHEMA_VERSION = '0.2.0';
 const PLATFORM = 'home-mcp-lab';
 
 /**
+ * Builds a schema-conforming session.start audit event.
+ *
+ * Required context fields:
+ *   projectId, agentId, mcpServer, correlationId
+ *
+ * Optional context fields:
+ *   initiatingContext, sessionType, executionMode
+ *
+ * Throws if any required field is missing.
+ */
+function buildSessionStartEvent(context) {
+  const required = ['projectId', 'agentId', 'mcpServer', 'correlationId'];
+  for (const field of required) {
+    if (!context[field]) {
+      throw new Error(`Missing required emitter context field: ${field}`);
+    }
+  }
+
+  const metadata = {
+    session_type: context.sessionType || 'interactive',
+    execution_mode: context.executionMode || 'agent-mediated'
+  };
+  if (context.initiatingContext) {
+    metadata.initiating_context = context.initiatingContext;
+  }
+
+  return {
+    schema_version: SCHEMA_VERSION,
+    event_id: randomUUID(),
+    event_type: 'session.start',
+    timestamp: new Date().toISOString(),
+    platform: PLATFORM,
+    project_id: context.projectId,
+    agent_id: context.agentId,
+    mcp_server: context.mcpServer,
+    action: 'mcp_session_init',
+    status: 'success',
+    correlation_id: context.correlationId,
+    metadata
+  };
+}
+
+/**
+ * Builds a schema-conforming session.end audit event.
+ *
+ * Required context fields:
+ *   projectId, agentId, mcpServer, correlationId
+ *
+ * Required outcome fields:
+ *   status ('success' | 'failure'), sessionStartTime (ms since epoch)
+ *
+ * Optional outcome fields:
+ *   completionReason, outcomeSummary, failureReason
+ *
+ * Throws if any required field is missing or invalid.
+ */
+function buildSessionEndEvent(context, outcome) {
+  const required = ['projectId', 'agentId', 'mcpServer', 'correlationId'];
+  for (const field of required) {
+    if (!context[field]) {
+      throw new Error(`Missing required emitter context field: ${field}`);
+    }
+  }
+
+  if (outcome.status !== 'success' && outcome.status !== 'failure') {
+    throw new Error(`Invalid session.end status: "${outcome.status}". Must be "success" or "failure".`);
+  }
+
+  const metadata = {
+    completion_reason: outcome.completionReason || (outcome.status === 'success' ? 'task_complete' : 'error'),
+    duration_ms: outcome.sessionStartTime != null ? (Date.now() - outcome.sessionStartTime) : null
+  };
+  if (outcome.outcomeSummary) {
+    metadata.outcome_summary = String(outcome.outcomeSummary).slice(0, 500);
+  }
+  if (outcome.status === 'failure' && outcome.failureReason) {
+    metadata.failure_reason = String(outcome.failureReason).slice(0, 500);
+  }
+  if (context.initiatingContext) {
+    metadata.initiating_context = context.initiatingContext;
+  }
+
+  return {
+    schema_version: SCHEMA_VERSION,
+    event_id: randomUUID(),
+    event_type: 'session.end',
+    timestamp: new Date().toISOString(),
+    platform: PLATFORM,
+    project_id: context.projectId,
+    agent_id: context.agentId,
+    mcp_server: context.mcpServer,
+    action: 'mcp_session_close',
+    status: outcome.status,
+    correlation_id: context.correlationId,
+    metadata
+  };
+}
+
+
+/**
  * Builds a schema-conforming tool.invocation audit event.
  *
  * Required context fields:
@@ -74,4 +174,4 @@ function buildToolInvocationEvent(context, outcome) {
   };
 }
 
-module.exports = { buildToolInvocationEvent };
+module.exports = { buildToolInvocationEvent, buildSessionStartEvent, buildSessionEndEvent };

--- a/src/emitter/index.js
+++ b/src/emitter/index.js
@@ -7,8 +7,11 @@
  * Emits tool.invocation audit events at tool call completion boundaries.
  *
  * Public API:
- *   emitToolInvocation(context, outcome)   — emit a single event (fire-and-forget)
+ *   withSession(baseContext, fn)           — run fn in a managed session; emits session.start and session.end
+ *   emitToolInvocation(context, outcome)   — emit a single tool.invocation event (fire-and-forget)
  *   withToolInstrumentation(context, fn)   — wrap an async tool call with instrumentation
+ *   emitSessionStart(context)              — emit session.start directly; returns correlationId
+ *   emitSessionEnd(context, outcome)       — emit session.end directly
  *
  * Context shape:
  *   toolName           string  required  — MCP tool name (e.g. "create_issue")
@@ -23,7 +26,7 @@
  */
 
 const { randomUUID } = require('crypto');
-const { buildToolInvocationEvent } = require('./event-builder');
+const { buildToolInvocationEvent, buildSessionStartEvent, buildSessionEndEvent } = require('./event-builder');
 const { submit } = require('./transport');
 const { record } = require('./failure-observer');
 
@@ -121,4 +124,104 @@ function classifyFailure(err) {
   return msg.slice(0, 300) || 'unknown_failure';
 }
 
-module.exports = { emitToolInvocation, withToolInstrumentation };
+/**
+ * Emit a session.start event.
+ * Never throws — emission failures are handled by the failure observer.
+ *
+ * Returns the correlationId used, so callers can propagate it to tool calls.
+ */
+function emitSessionStart(context) {
+  try {
+    const resolvedContext = {
+      ...context,
+      correlationId: context.correlationId || generateCorrelationId()
+    };
+    const event = buildSessionStartEvent(resolvedContext);
+    submit(event);
+    return resolvedContext.correlationId;
+  } catch (err) {
+    record(err, { event_type: 'session.start', projectId: context.projectId });
+    // Return a generated ID so session can continue even if emission failed.
+    return context.correlationId || generateCorrelationId();
+  }
+}
+
+/**
+ * Emit a session.end event.
+ * Never throws — emission failures are handled by the failure observer.
+ *
+ * outcome shape:
+ *   status             'success' | 'failure'  required
+ *   sessionStartTime   number                 required — ms since epoch from session start
+ *   completionReason   string                 optional
+ *   outcomeSummary     string                 optional
+ *   failureReason      string                 required when status is 'failure'
+ */
+function emitSessionEnd(context, outcome) {
+  try {
+    const event = buildSessionEndEvent(context, outcome);
+    submit(event);
+  } catch (err) {
+    record(err, { event_type: 'session.end', correlationId: context.correlationId });
+  }
+}
+
+/**
+ * Run an async function within a managed session.
+ *
+ * Emits session.start before calling fn, injects correlationId into every
+ * withToolInstrumentation call inside fn, and emits session.end after fn
+ * completes — whether it succeeds or throws.
+ *
+ * session.end emits status:'failure' if fn throws; status:'success' otherwise.
+ * The original error is always re-thrown after session.end is emitted.
+ *
+ * baseContext shape — same as tool emitter context minus toolName/correlationId:
+ *   projectId          string  required
+ *   agentId            string  required
+ *   mcpServer          string  required
+ *   initiatingContext  string  optional
+ *   sessionType        string  optional  — default 'interactive'
+ *   executionMode      string  optional  — default 'agent-mediated'
+ *
+ * fn receives (sessionContext) — a context object with correlationId populated,
+ * suitable for passing directly to withToolInstrumentation or emitToolInvocation.
+ *
+ * Example:
+ *   await withSession(
+ *     { projectId: 'home-mcp-lab', agentId: 'claude-code-1',
+ *       mcpServer: 'github-mcp-server', initiatingContext: 'CC-HMCP-000004C' },
+ *     async (sessionCtx) => {
+ *       await withToolInstrumentation({ ...sessionCtx, toolName: 'get_file_contents' }, () => mcp.getFile(...));
+ *       await withToolInstrumentation({ ...sessionCtx, toolName: 'create_issue' }, () => mcp.createIssue(...));
+ *     }
+ *   );
+ */
+async function withSession(baseContext, fn) {
+  const correlationId = emitSessionStart(baseContext);
+  const sessionContext = { ...baseContext, correlationId };
+  const sessionStartTime = Date.now();
+
+  let result;
+  try {
+    result = await fn(sessionContext);
+  } catch (err) {
+    emitSessionEnd(sessionContext, {
+      status: 'failure',
+      sessionStartTime,
+      completionReason: 'error',
+      failureReason: err && err.message ? err.message.slice(0, 300) : 'unknown_error'
+    });
+    throw err;
+  }
+
+  emitSessionEnd(sessionContext, {
+    status: 'success',
+    sessionStartTime,
+    completionReason: 'task_complete'
+  });
+
+  return result;
+}
+
+module.exports = { emitToolInvocation, withToolInstrumentation, emitSessionStart, emitSessionEnd, withSession };


### PR DESCRIPTION
## Summary
Implements CC-HMCP-000004C — Session Lifecycle Instrumentation (Phase 2 Slice 2).

This PR extends the existing Model C emitter (introduced in CC-HMCP-000004B) to support session-level observability by emitting `session.start` and `session.end` events and propagating session context across all `tool.invocation` events.

This upgrade transforms isolated tool events into coherent, traceable execution narratives.

## Context
- ADR-HMCP-002 (PR #22) defines the instrumentation contract
- CC-HMCP-000004B (PR #23) implemented tool-level event emission
- The system currently emits tool events but lacks session boundaries
- This PR introduces session-level traceability without modifying existing event semantics

## What This PR Does

### Session Lifecycle Events
- Adds emission of:
  - `session.start` (once per session)
  - `session.end` (once per session)
- Defines a session as a single logical execution boundary (e.g., one CC-HMCP task run)

### Session Context Propagation
- Introduces session context via `correlation_id`
- All events within a session share the same `correlation_id`
- No new `session_id` field introduced (schema-aligned)

### API Additions
- `withSession(fn, context)`
  - Wraps execution in a session boundary
  - Automatically emits `session.start` and `session.end`
- `emitSessionStart()` / `emitSessionEnd()`
  - Lower-level control for session lifecycle (if needed)

### Module Changes
- `src/emitter/event-builder.js`
  - Added `buildSessionStartEvent()` and `buildSessionEndEvent()`
- `src/emitter/index.js`
  - Added session APIs and updated exports
- `src/emitter/demo-session.js`
  - Demonstrates multi-scenario session behavior

## Session Semantics

### Session Outcome Rule
- A session is **successful if the wrapped function completes without throwing**
- Tool-level failures **do not fail the session** if they are handled internally

Example:
- Tool failure caught inside session → `session.end: success`
- Unhandled error → `session.end: failure`

This explicitly separates:
- tool execution outcomes
- workflow/session completion

## Validation

Three scenarios validated:

| Scenario | session.start | tool.invocation | session.end | session.end status |
|----------|--------------|-----------------|-------------|-------------------|
| Clean multi-step session | ✓ | ✓ (all success) | ✓ | success |
| Tool failure mid-session | ✓ | ✓ (mixed) | ✓ | success |
| Session-level failure | ✓ | ✓ | ✓ | failure |

All events:
- Conform to schema v0.2.0
- Include required fields
- Maintain consistent `correlation_id` per session
- Do not leak correlation across sessions

## ADR Alignment

This implementation adheres strictly to ADR-HMCP-002:

- ✅ Model C (agent-mediated emission)
- ✅ Non-blocking emission
- ✅ Explicit failure semantics
- ✅ Schema v0.2.0 compliance
- ✅ No schema expansion (no `pending`)
- ❌ No MCP server modification
- ❌ No proxy/interception layer

## Visibility Gap Impact

| Gap | Status |
|-----|--------|
| VG-HMCP-000002 — Tool Invocation Visibility | ✅ Resolved |
| VG-HMCP-000004 — Session Lifecycle Visibility | ✅ Resolved in this slice |
| VG-HMCP-000003 — Secret Retrieval Path Visibility | ⚠️ Unchanged |
| VG-HMCP-000001 — Keeper Non-Interactive Retrieval | ❌ Unchanged |

## Limitations (Intentional)

- No orphan session detection (missing `session.end`)
  - Requires platform-level monitoring (outside emitter scope)
- No `pending` status (start-phase events)
  - Requires schema MINOR update
- No session outcome summary aggregation
  - Raw events remain the source of truth
- Transport remains local JSONL (unchanged from previous slice)

## Consequences

### Positive
- Enables full session-level traceability
- Allows reconstruction of execution sequences
- Preserves modular, replaceable emitter design
- Maintains strict alignment with ADR-HMCP-002

### Tradeoffs
- No guarantees on session completeness under process failure
- Session semantics depend on correct use of `withSession()`
- No aggregation or summarization of session outcomes yet

## Next Steps

- **CC-HMCP-000004D — Transport: Ingestion Boundary (HTTP Endpoint)**
  - Replace JSONL transport with ingestion endpoint
- Investigate VG-HMCP-000003 (GitHub PAT retrieval path)
- Introduce schema MINOR update for `pending` status
- Consider session-level summarization (future slice)

## Notes

- Existing `tool.invocation` behavior remains unchanged
- Standalone (non-session) emission is still supported
- No external dependencies introduced
- Implementation extends existing modules without restructuring

---

This PR upgrades the system from emitting isolated events to producing structured, session-aware execution traces.