### PR TITLE
Implements CC-HMCP-000004D — Transport: Ingestion Boundary (HTTP Endpoint)

### DIFF
--- a/src/emitter/transport.js
+++ b/src/emitter/transport.js
@@ -1,27 +1,116 @@
 'use strict';
 
 const fs = require('fs');
+const http = require('http');
+const https = require('https');
 const path = require('path');
+const { record } = require('./failure-observer');
 
+// ── Configuration ────────────────────────────────────────────────────────────
+
+const INGESTION_URL = process.env.EVENT_INGESTION_URL || null;
+const REQUEST_TIMEOUT_MS = 5000;
+
+// JSONL fallback — used when INGESTION_URL is not configured.
 const AUDIT_LOG_DIR = path.join(__dirname, '..', '..', 'audit-log');
 const AUDIT_LOG_FILE = path.join(AUDIT_LOG_DIR, 'tool-invocations.jsonl');
 
+// ── Public interface ─────────────────────────────────────────────────────────
+
 /**
- * Submits a validated audit event to the local JSONL audit log.
+ * Submit a validated audit event to the configured ingestion target.
  *
- * Phase 2 transport: local append-only JSONL file.
- * The platform ingestion boundary (HTTP endpoint) is not yet implemented.
- * When the ingestion boundary is available, this module is replaced
- * without changes to the emitter interface.
+ * When EVENT_INGESTION_URL is set:
+ *   HTTP POST the event as JSON. Delivery is async and non-blocking.
+ *   The function returns before the request completes.
+ *   Delivery failures are observed via the failure observer — they do not
+ *   propagate to the caller.
  *
- * Throws on I/O failure. Callers must catch — transport failure must
- * be handled by the failure observer, not propagated to the tool call.
+ * When EVENT_INGESTION_URL is not set (fallback):
+ *   Append the event to the local JSONL file. This is synchronous.
+ *   I/O failures are thrown to the caller so the emitter can observe them.
+ *
+ * Throws synchronously only for events that cannot be serialized (should not
+ * happen in practice given validated event objects from event-builder.js).
  */
 function submit(event) {
+  const payload = JSON.stringify(event);
+
+  if (INGESTION_URL) {
+    _postAsync(payload, event.event_id);
+    // Returns immediately — delivery happens asynchronously.
+    return;
+  }
+
+  // Fallback: local JSONL
   if (!fs.existsSync(AUDIT_LOG_DIR)) {
     fs.mkdirSync(AUDIT_LOG_DIR, { recursive: true });
   }
-  fs.appendFileSync(AUDIT_LOG_FILE, JSON.stringify(event) + '\n', 'utf8');
+  fs.appendFileSync(AUDIT_LOG_FILE, payload + '\n', 'utf8');
 }
 
-module.exports = { submit, AUDIT_LOG_FILE };
+// ── Internal ─────────────────────────────────────────────────────────────────
+
+/**
+ * Fire-and-forget HTTP POST. All delivery failures are observed locally.
+ * Never throws or rejects to the caller.
+ */
+function _postAsync(payload, eventId) {
+  _post(payload)
+    .catch(err => {
+      record(err, {
+        transport: 'http',
+        event_id: eventId,
+        endpoint: INGESTION_URL
+      });
+    });
+}
+
+/**
+ * HTTP POST with timeout. Returns a Promise that resolves on 2xx
+ * and rejects on non-2xx, network error, or timeout.
+ */
+function _post(payload) {
+  return new Promise((resolve, reject) => {
+    const url = new URL(INGESTION_URL);
+    const lib = url.protocol === 'https:' ? https : http;
+    const body = Buffer.from(payload, 'utf8');
+
+    const req = lib.request(
+      {
+        hostname: url.hostname,
+        port: url.port || (url.protocol === 'https:' ? 443 : 80),
+        path: url.pathname + url.search,
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Content-Length': body.length
+        },
+        timeout: REQUEST_TIMEOUT_MS
+      },
+      (res) => {
+        // Drain the response body so the socket is released.
+        res.resume();
+        if (res.statusCode >= 200 && res.statusCode < 300) {
+          resolve(res.statusCode);
+        } else {
+          reject(new Error(`ingestion_endpoint_rejected: HTTP ${res.statusCode}`));
+        }
+      }
+    );
+
+    req.on('timeout', () => {
+      req.destroy();
+      reject(new Error('delivery_timed_out'));
+    });
+
+    req.on('error', (err) => {
+      reject(new Error(`delivery_network_error: ${err.message}`));
+    });
+
+    req.write(body);
+    req.end();
+  });
+}
+
+module.exports = { submit, AUDIT_LOG_FILE, INGESTION_URL };

--- a/src/ingestion/server.js
+++ b/src/ingestion/server.js
@@ -1,0 +1,73 @@
+'use strict';
+
+/**
+ * Phase 2 ingestion boundary — minimal HTTP server.
+ *
+ * Accepts POST /events, validates Content-Type, logs received events.
+ * This is the platform ingestion boundary for Phase 2.
+ * It does not persist events — persistence is a future slice.
+ *
+ * Usage:
+ *   node src/ingestion/server.js
+ *   EVENT_INGESTION_URL=http://localhost:4318/events node src/emitter/demo-session.js
+ *
+ * Default port: 4318 (configurable via PORT env var)
+ */
+
+const http = require('http');
+
+const PORT = parseInt(process.env.PORT || '4318', 10);
+let receivedCount = 0;
+
+const server = http.createServer((req, res) => {
+  if (req.method === 'POST' && req.url === '/events') {
+    handleEvent(req, res);
+    return;
+  }
+
+  res.writeHead(404, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify({ error: 'not_found' }));
+});
+
+function handleEvent(req, res) {
+  const chunks = [];
+
+  req.on('data', chunk => chunks.push(chunk));
+
+  req.on('end', () => {
+    const raw = Buffer.concat(chunks).toString('utf8');
+
+    let event;
+    try {
+      event = JSON.parse(raw);
+    } catch {
+      res.writeHead(400, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'invalid_json' }));
+      return;
+    }
+
+    if (!req.headers['content-type'] || !req.headers['content-type'].includes('application/json')) {
+      res.writeHead(415, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'unsupported_media_type' }));
+      return;
+    }
+
+    receivedCount++;
+    console.log(`\n[${new Date().toISOString()}] Event #${receivedCount} received`);
+    console.log(JSON.stringify(event, null, 2));
+
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ accepted: true, event_id: event.event_id || null }));
+  });
+
+  req.on('error', (err) => {
+    console.error('Request error:', err.message);
+    res.writeHead(500, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'internal_error' }));
+  });
+}
+
+server.listen(PORT, () => {
+  console.log(`Ingestion boundary listening on http://localhost:${PORT}/events`);
+  console.log('Waiting for events...\n');
+});


### PR DESCRIPTION
## Summary
Implements CC-HMCP-000004D — Transport: Ingestion Boundary (HTTP Endpoint).

This PR replaces the local JSONL transport with an HTTP-based ingestion boundary while preserving the emitter interface and event schema. It establishes the first system-level entry point for MCP tool call events.

## Context
- ADR-HMCP-002 (PR #22) defines the instrumentation contract
- CC-HMCP-000004B (PR #23) introduced tool invocation event emission
- CC-HMCP-000004C (PR #24) added session lifecycle instrumentation
- Events were previously written only to local JSONL (no system boundary)

This PR introduces a minimal ingestion boundary so events can leave the process and enter the platform.

## What This PR Does

### HTTP Transport
- Replaces JSONL append with HTTP POST in `src/emitter/transport.js`
- Sends one event per request (no batching)
- Endpoint configurable via `EVENT_INGESTION_URL`

### Fallback Behavior
- If `EVENT_INGESTION_URL` is not set:
  - Falls back to JSONL file (`audit-log/tool-invocations.jsonl`)
- Preserves existing local development workflow

### Ingestion Server
- Adds `src/ingestion/server.js`
- Minimal HTTP server:
  - Accepts `POST /events`
  - Logs received events to stdout
- No persistence or processing logic (intentionally minimal)

### Delivery Semantics
- HTTP delivery is **non-blocking**
  - Event submission returns immediately
  - Delivery success/failure handled asynchronously
- Delivery failures:
  - Observed via `failure-observer`
  - Never propagated to caller
- Timeout and network errors treated as emission failures

## Configuration

| Variable | Default | Behavior |
|----------|--------|----------|
| EVENT_INGESTION_URL | not set | JSONL fallback |
| EVENT_INGESTION_URL=http://localhost:4318/events | — | HTTP transport enabled |
| PORT | 4318 | Ingestion server port |

## Validation

### Successful Delivery
- 13 events delivered to ingestion server
- All events:
  - Schema v0.2.0 compliant
  - Required fields present
  - Session correlation intact

### Failure Scenario (Server Down)
- Events attempted → delivery failed (ECONNREFUSED)
- Failures recorded via `[emitter-failure]`
- No errors propagated to caller
- Tool execution and session completed normally

## ADR Alignment

This implementation adheres strictly to ADR-HMCP-002:

- ✅ Model C (agent-mediated emission)
- ✅ Non-blocking emission
- ✅ No schema changes
- ✅ No MCP server modification
- ❌ No retry/buffering system (deferred)
- ❌ No persistence layer (deferred)

## Visibility Gap Impact

| Gap | Status |
|-----|--------|
| VG-HMCP-000002 — Tool Invocation Visibility | ✅ Resolved |
| VG-HMCP-000004 — Session Lifecycle Visibility | ✅ Resolved |
| VG-HMCP-000003 — Secret Retrieval Path Visibility | ⚠️ Unchanged |
| VG-HMCP-000001 — Keeper Non-Interactive Retrieval | ❌ Unchanged |

## Limitations (Intentional)

- No persistence at ingestion boundary (stdout only)
- No retry or buffering (events may be lost)
- No authentication or authorization
- Demo read-back assumes JSONL (HTTP mode not reflected locally)

## Consequences

### Positive
- Establishes a real ingestion boundary for events
- Enables future centralization and storage
- Preserves emitter interface and modular design
- Maintains ADR-compliant behavior

### Tradeoffs
- Events are not yet durable
- Delivery is best-effort only
- Ingestion layer is minimal and non-production-ready

## Next Steps

- **CC-HMCP-000004E — Ingestion Persistence Layer**
  - Store events (append-only or database)
- Introduce bounded retry/backoff policy
- Add authentication to ingestion endpoint
- Improve demo read-back for HTTP mode

## Notes

- No changes to emitter API or schema
- `transport.js` remains the only transport boundary
- Implementation intentionally minimal to establish system seam

---

This PR upgrades the system from local event emission to a platform-level ingestion pipeline, enabling future persistence, querying, and analysis.