### PR TITLE
Implements CC-HMCP-000004E — Ingestion Persistence Layer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,5 +25,8 @@ __pycache__/
 *.tmp
 *.swp
 
-# Runtime audit log (local Phase 2 transport — not committed)
+# Runtime audit log (emitter-side JSONL fallback — not committed)
 audit-log/
+
+# Ingestion boundary persistence store (server-side — not committed)
+ingestion-store/

--- a/src/ingestion/server.js
+++ b/src/ingestion/server.js
@@ -1,23 +1,36 @@
 'use strict';
 
 /**
- * Phase 2 ingestion boundary — minimal HTTP server.
+ * Phase 2 ingestion boundary — minimal HTTP server with append-only persistence.
  *
- * Accepts POST /events, validates Content-Type, logs received events.
- * This is the platform ingestion boundary for Phase 2.
- * It does not persist events — persistence is a future slice.
+ * Accepts POST /events, validates Content-Type, persists the event to a local
+ * JSONL store, then returns 200. The 200 response means the event is durably
+ * written. If persistence fails, the server returns 500 and does not crash.
  *
  * Usage:
  *   node src/ingestion/server.js
  *   EVENT_INGESTION_URL=http://localhost:4318/events node src/emitter/demo-session.js
  *
+ * Persisted events: ingestion-store/events.jsonl (excluded from git)
  * Default port: 4318 (configurable via PORT env var)
  */
 
 const http = require('http');
+const fs = require('fs');
+const path = require('path');
 
 const PORT = parseInt(process.env.PORT || '4318', 10);
+
+const STORE_DIR = path.join(__dirname, '..', '..', 'ingestion-store');
+const STORE_FILE = path.join(STORE_DIR, 'events.jsonl');
+
 let receivedCount = 0;
+let persistedCount = 0;
+
+// Ensure the storage directory exists at startup.
+if (!fs.existsSync(STORE_DIR)) {
+  fs.mkdirSync(STORE_DIR, { recursive: true });
+}
 
 const server = http.createServer((req, res) => {
   if (req.method === 'POST' && req.url === '/events') {
@@ -37,6 +50,13 @@ function handleEvent(req, res) {
   req.on('end', () => {
     const raw = Buffer.concat(chunks).toString('utf8');
 
+    // Validate Content-Type before parsing.
+    if (!req.headers['content-type'] || !req.headers['content-type'].includes('application/json')) {
+      res.writeHead(415, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'unsupported_media_type' }));
+      return;
+    }
+
     let event;
     try {
       event = JSON.parse(raw);
@@ -46,22 +66,27 @@ function handleEvent(req, res) {
       return;
     }
 
-    if (!req.headers['content-type'] || !req.headers['content-type'].includes('application/json')) {
-      res.writeHead(415, { 'Content-Type': 'application/json' });
-      res.end(JSON.stringify({ error: 'unsupported_media_type' }));
+    receivedCount++;
+
+    // Persist before responding. 200 means durably written.
+    try {
+      fs.appendFileSync(STORE_FILE, raw + '\n', 'utf8');
+      persistedCount++;
+    } catch (err) {
+      console.error(`[${new Date().toISOString()}] persistence_failure event_id=${event.event_id || 'unknown'} error=${err.message}`);
+      res.writeHead(500, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'persistence_failure' }));
       return;
     }
 
-    receivedCount++;
-    console.log(`\n[${new Date().toISOString()}] Event #${receivedCount} received`);
-    console.log(JSON.stringify(event, null, 2));
+    console.log(`[${new Date().toISOString()}] accepted event_id=${event.event_id} event_type=${event.event_type} correlation_id=${event.correlation_id} (total persisted: ${persistedCount})`);
 
     res.writeHead(200, { 'Content-Type': 'application/json' });
     res.end(JSON.stringify({ accepted: true, event_id: event.event_id || null }));
   });
 
   req.on('error', (err) => {
-    console.error('Request error:', err.message);
+    console.error(`[${new Date().toISOString()}] request_error: ${err.message}`);
     res.writeHead(500, { 'Content-Type': 'application/json' });
     res.end(JSON.stringify({ error: 'internal_error' }));
   });
@@ -69,5 +94,6 @@ function handleEvent(req, res) {
 
 server.listen(PORT, () => {
   console.log(`Ingestion boundary listening on http://localhost:${PORT}/events`);
+  console.log(`Persisting to: ${STORE_FILE}`);
   console.log('Waiting for events...\n');
 });


### PR DESCRIPTION
## Summary
Implements CC-HMCP-000004E — Ingestion Persistence Layer.

This PR adds durable append-only persistence to the ingestion boundary so accepted events are retained as system records. Events received by `POST /events` are now written to local JSONL storage before the server returns HTTP 200.

## Context
- ADR-HMCP-002 (PR #22) defines the instrumentation contract
- CC-HMCP-000004B (PR #23) introduced tool invocation emission
- CC-HMCP-000004C (PR #24) added session lifecycle instrumentation
- CC-HMCP-000004D (PR #25) established the HTTP ingestion boundary
- Until this PR, the ingestion server accepted events but only logged them to stdout

This PR makes the ingestion boundary durable.

## What This PR Does

### Durable Persistence
- Modifies `src/ingestion/server.js`
- Accepted events are appended to:

  `ingestion-store/events.jsonl`

- Storage is append-only, one JSON event per line
- Events are written in server arrival order

### HTTP Success Semantics
- Server returns HTTP 200 only after the event has been successfully persisted
- If persistence fails:
  - server returns HTTP 500
  - response body: `{"error":"persistence_failure"}`
  - failure is logged
  - server remains running

### Runtime Data Handling
- Adds `ingestion-store/` to `.gitignore`
- Keeps runtime event data out of source control

## Storage Model

| Path | Written by | Purpose |
|------|------------|---------|
| `ingestion-store/events.jsonl` | Ingestion server | Durable append-only system record |
| `audit-log/tool-invocations.jsonl` | Emitter fallback only | Local fallback when ingestion endpoint is not configured |

## Validation

### Successful Delivery
- 13 events delivered and persisted across 3 sessions
- Verified persisted sequence includes:
  - `session.start`
  - `tool.invocation`
  - `session.end`
- Verified both:
  - tool-level failure persisted
  - session-level failure persisted

Example persisted outcomes:
- tool failure persisted with `status=failure`
- session failure persisted with `session.end status=failure`

### Persistence Failure
- Simulated file lock / write failure
- Server returned HTTP 500 with `{"error":"persistence_failure"}`
- Error logged
- Server stayed alive
- Next event persisted normally after file was available again

## ADR Alignment

This implementation remains aligned with ADR-HMCP-002:

- ✅ append-only audit/event storage
- ✅ no schema changes
- ✅ no emitter API changes
- ✅ explicit success/failure semantics at the ingestion boundary
- ✅ minimal, replaceable persistence model
- ❌ no retries/backoff
- ❌ no query/read API
- ❌ no auth/authz
- ❌ no deduplication

## Visibility Gap Impact

| Gap | Status |
|-----|--------|
| VG-HMCP-000002 — Tool Invocation Visibility | ✅ Resolved |
| VG-HMCP-000004 — Session Lifecycle Visibility | ✅ Resolved |
| VG-HMCP-000003 — Secret Retrieval Path Visibility | ⚠️ Unchanged |
| VG-HMCP-000001 — Keeper Non-Interactive Retrieval | ❌ Unchanged |

## Limitations (Intentional)

- No deduplication
  - future retries could create duplicate persisted events
- Unbounded file growth
  - no rotation or archival yet
- No read/query API
  - inspection is file-based (`cat`, `jq`, etc.)
- Single-file storage
  - no partitioning by date/session/event type
- Synchronous file write
  - blocks Node.js event loop briefly during append
  - acceptable for current low-volume home-lab context

## Consequences

### Positive
- Establishes durable event retention at the ingestion boundary
- Makes HTTP 200 meaningful: accepted and persisted
- Preserves append-only system memory
- Keeps architecture simple and replaceable

### Tradeoffs
- Persistence is local-file based, not scalable
- No replay/query ergonomics yet
- No duplicate protection
- No throughput optimization

## Next Steps

- **CC-HMCP-000004F — Readback / Inspection Path**
  - minimal way to inspect persisted events without shell-only workflows

Potential later follow-ons:
- bounded retry/backoff
- deduplication via event IDs
- storage rotation/archival
- authenticated ingestion boundary

## Notes

- No emitter files were changed
- No schema modifications were introduced
- The ingestion boundary now owns durable append-only event storage

---

This PR upgrades the platform from transient event receipt to durable event retention, establishing append-only system memory without expanding into analytics, querying, or storage platform concerns.