### PR TITLE
Implements CC-HMCP-000004F — Readback / Inspection Path

### DIFF
--- a/src/ingestion/server.js
+++ b/src/ingestion/server.js
@@ -1,28 +1,44 @@
 'use strict';
 
 /**
- * Phase 2 ingestion boundary — minimal HTTP server with append-only persistence.
+ * Phase 2 ingestion boundary — HTTP server with persistence and readback.
  *
- * Accepts POST /events, validates Content-Type, persists the event to a local
- * JSONL store, then returns 200. The 200 response means the event is durably
- * written. If persistence fails, the server returns 500 and does not crash.
+ * Routes:
+ *   POST /events          Accept and persist a single audit event.
+ *                         Returns 200 only after the event is durably written.
+ *                         Returns 500 if persistence fails.
+ *
+ *   GET  /events          Read back persisted events.
+ *                         Query parameters (all optional):
+ *                           correlation_id  — filter to a single session
+ *                           event_type      — filter to a specific event type
+ *                           limit           — max events to return (default: 100, max: 1000)
+ *                         If the store file does not exist, returns {"events":[],"count":0}.
+ *                         If the store file cannot be read, returns 500.
+ *
+ * Storage:
+ *   ingestion-store/events.jsonl  — append-only; one JSON event per line.
+ *   Excluded from git.
  *
  * Usage:
  *   node src/ingestion/server.js
  *   EVENT_INGESTION_URL=http://localhost:4318/events node src/emitter/demo-session.js
  *
- * Persisted events: ingestion-store/events.jsonl (excluded from git)
  * Default port: 4318 (configurable via PORT env var)
  */
 
 const http = require('http');
 const fs = require('fs');
 const path = require('path');
+const { URL } = require('url');
 
 const PORT = parseInt(process.env.PORT || '4318', 10);
 
 const STORE_DIR = path.join(__dirname, '..', '..', 'ingestion-store');
 const STORE_FILE = path.join(STORE_DIR, 'events.jsonl');
+
+const DEFAULT_LIMIT = 100;
+const MAX_LIMIT = 1000;
 
 let receivedCount = 0;
 let persistedCount = 0;
@@ -33,8 +49,15 @@ if (!fs.existsSync(STORE_DIR)) {
 }
 
 const server = http.createServer((req, res) => {
-  if (req.method === 'POST' && req.url === '/events') {
-    handleEvent(req, res);
+  const reqUrl = new URL(req.url, `http://localhost:${PORT}`);
+
+  if (req.method === 'POST' && reqUrl.pathname === '/events') {
+    handlePost(req, res);
+    return;
+  }
+
+  if (req.method === 'GET' && reqUrl.pathname === '/events') {
+    handleGet(reqUrl, res);
     return;
   }
 
@@ -42,7 +65,9 @@ const server = http.createServer((req, res) => {
   res.end(JSON.stringify({ error: 'not_found' }));
 });
 
-function handleEvent(req, res) {
+// ── POST /events ─────────────────────────────────────────────────────────────
+
+function handlePost(req, res) {
   const chunks = [];
 
   req.on('data', chunk => chunks.push(chunk));
@@ -50,7 +75,6 @@ function handleEvent(req, res) {
   req.on('end', () => {
     const raw = Buffer.concat(chunks).toString('utf8');
 
-    // Validate Content-Type before parsing.
     if (!req.headers['content-type'] || !req.headers['content-type'].includes('application/json')) {
       res.writeHead(415, { 'Content-Type': 'application/json' });
       res.end(JSON.stringify({ error: 'unsupported_media_type' }));
@@ -68,7 +92,6 @@ function handleEvent(req, res) {
 
     receivedCount++;
 
-    // Persist before responding. 200 means durably written.
     try {
       fs.appendFileSync(STORE_FILE, raw + '\n', 'utf8');
       persistedCount++;
@@ -91,6 +114,56 @@ function handleEvent(req, res) {
     res.end(JSON.stringify({ error: 'internal_error' }));
   });
 }
+
+// ── GET /events ──────────────────────────────────────────────────────────────
+
+function handleGet(reqUrl, res) {
+  const correlationId = reqUrl.searchParams.get('correlation_id') || null;
+  const eventType = reqUrl.searchParams.get('event_type') || null;
+  const limitParam = parseInt(reqUrl.searchParams.get('limit') || String(DEFAULT_LIMIT), 10);
+  const limit = isNaN(limitParam) || limitParam < 1 ? DEFAULT_LIMIT : Math.min(limitParam, MAX_LIMIT);
+
+  // File not present — valid empty state (server running, no events received yet).
+  if (!fs.existsSync(STORE_FILE)) {
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ events: [], count: 0 }));
+    return;
+  }
+
+  let raw;
+  try {
+    raw = fs.readFileSync(STORE_FILE, 'utf8');
+  } catch (err) {
+    console.error(`[${new Date().toISOString()}] readback_failure error=${err.message}`);
+    res.writeHead(500, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'readback_failure' }));
+    return;
+  }
+
+  const lines = raw.split('\n').filter(l => l.trim().length > 0);
+  const events = [];
+
+  for (const line of lines) {
+    let event;
+    try {
+      event = JSON.parse(line);
+    } catch {
+      // Skip malformed lines — do not crash or reject the response.
+      continue;
+    }
+
+    if (correlationId && event.correlation_id !== correlationId) continue;
+    if (eventType && event.event_type !== eventType) continue;
+
+    events.push(event);
+    if (events.length >= limit) break;
+  }
+
+  res.writeHead(200, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify({ events, count: events.length }));
+}
+
+// ── Start ────────────────────────────────────────────────────────────────────
 
 server.listen(PORT, () => {
   console.log(`Ingestion boundary listening on http://localhost:${PORT}/events`);


### PR DESCRIPTION
## Summary
Implements CC-HMCP-000004F — Readback / Inspection Path.

This PR adds a minimal HTTP readback path to the ingestion server so persisted events can be inspected without relying solely on shell tools. Operators can now retrieve stored events from `ingestion-store/events.jsonl` using simple filters.

## Context
- ADR-HMCP-002 (PR #22) defines the instrumentation contract
- CC-HMCP-000004B (PR #23) introduced tool invocation emission
- CC-HMCP-000004C (PR #24) added session lifecycle instrumentation
- CC-HMCP-000004D (PR #25) established the HTTP ingestion boundary
- CC-HMCP-000004E (PR #26) added durable append-only persistence
- Persisted events were still only inspectable via shell tools (`cat`, `jq`, etc.)

This PR exposes the stored truth through the ingestion boundary in the smallest useful way.

## What This PR Does

### Readback Endpoint
Adds:

- `GET /events`

Returns:

```json
{ "events": [...], "count": N }