### PR TITLE
Implements CC-HMCP-000004G — Retry / Backoff Semantics for Event Delivery

### DIFF
--- a/src/emitter/transport.js
+++ b/src/emitter/transport.js
@@ -11,6 +11,11 @@ const { record } = require('./failure-observer');
 const INGESTION_URL = process.env.EVENT_INGESTION_URL || null;
 const REQUEST_TIMEOUT_MS = 5000;
 
+// Retry policy — applies to HTTP delivery only.
+// Total delivery attempts = MAX_ATTEMPTS (1 initial + MAX_ATTEMPTS-1 retries).
+const MAX_ATTEMPTS = 3;
+const RETRY_DELAY_MS = 500;
+
 // JSONL fallback — used when INGESTION_URL is not configured.
 const AUDIT_LOG_DIR = path.join(__dirname, '..', '..', 'audit-log');
 const AUDIT_LOG_FILE = path.join(AUDIT_LOG_DIR, 'tool-invocations.jsonl');
@@ -21,23 +26,26 @@ const AUDIT_LOG_FILE = path.join(AUDIT_LOG_DIR, 'tool-invocations.jsonl');
  * Submit a validated audit event to the configured ingestion target.
  *
  * When EVENT_INGESTION_URL is set:
- *   HTTP POST the event as JSON. Delivery is async and non-blocking.
- *   The function returns before the request completes.
- *   Delivery failures are observed via the failure observer — they do not
- *   propagate to the caller.
+ *   HTTP POST the event as JSON with bounded retry on transient failures.
+ *   Delivery is async and non-blocking — the function returns before the
+ *   first attempt completes. Retries and final failure are observed via
+ *   the failure observer. They do not propagate to the caller.
+ *
+ *   Retry policy:
+ *     - Max 3 attempts (1 initial + 2 retries)
+ *     - Fixed 500ms delay between attempts
+ *     - Retry-eligible: network errors, timeouts, HTTP 5xx
+ *     - Non-retryable: HTTP 4xx (permanent client error)
  *
  * When EVENT_INGESTION_URL is not set (fallback):
- *   Append the event to the local JSONL file. This is synchronous.
+ *   Append the event to the local JSONL file. Synchronous.
  *   I/O failures are thrown to the caller so the emitter can observe them.
- *
- * Throws synchronously only for events that cannot be serialized (should not
- * happen in practice given validated event objects from event-builder.js).
  */
 function submit(event) {
   const payload = JSON.stringify(event);
 
   if (INGESTION_URL) {
-    _postAsync(payload, event.event_id);
+    _postWithRetry(payload, event.event_id);
     // Returns immediately — delivery happens asynchronously.
     return;
   }
@@ -52,23 +60,51 @@ function submit(event) {
 // ── Internal ─────────────────────────────────────────────────────────────────
 
 /**
- * Fire-and-forget HTTP POST. All delivery failures are observed locally.
- * Never throws or rejects to the caller.
+ * Async bounded retry loop. Fires and forgets from the caller's perspective.
+ * On final failure, records via failure-observer.
  */
-function _postAsync(payload, eventId) {
-  _post(payload)
-    .catch(err => {
-      record(err, {
-        transport: 'http',
-        event_id: eventId,
-        endpoint: INGESTION_URL
-      });
+function _postWithRetry(payload, eventId) {
+  _attemptDelivery(payload, eventId, 1);
+}
+
+async function _attemptDelivery(payload, eventId, attempt) {
+  let statusCode;
+  try {
+    statusCode = await _post(payload);
+    // Delivered successfully on attempt N.
+    if (attempt > 1) {
+      // Log recovery only when a retry was needed — keeps success path silent.
+      process.stderr.write(
+        `[emitter-retry-success] event_id=${eventId} delivered on attempt ${attempt}\n`
+      );
+    }
+    return;
+  } catch (err) {
+    const retryable = _isRetryable(err);
+
+    if (retryable && attempt < MAX_ATTEMPTS) {
+      process.stderr.write(
+        `[emitter-retry] event_id=${eventId} attempt=${attempt} error=${err.message} retrying_in=${RETRY_DELAY_MS}ms\n`
+      );
+      await _sleep(RETRY_DELAY_MS);
+      return _attemptDelivery(payload, eventId, attempt + 1);
+    }
+
+    // Non-retryable error, or retry budget exhausted.
+    record(err, {
+      transport: 'http',
+      event_id: eventId,
+      endpoint: INGESTION_URL,
+      attempts: attempt,
+      retryable
     });
+  }
 }
 
 /**
- * HTTP POST with timeout. Returns a Promise that resolves on 2xx
- * and rejects on non-2xx, network error, or timeout.
+ * Single HTTP POST attempt with timeout.
+ * Resolves with HTTP status code on 2xx.
+ * Rejects with a classified error on non-2xx, network failure, or timeout.
  */
 function _post(payload) {
   return new Promise((resolve, reject) => {
@@ -89,12 +125,19 @@ function _post(payload) {
         timeout: REQUEST_TIMEOUT_MS
       },
       (res) => {
-        // Drain the response body so the socket is released.
         res.resume();
         if (res.statusCode >= 200 && res.statusCode < 300) {
           resolve(res.statusCode);
+        } else if (res.statusCode >= 500) {
+          const err = new Error(`server_error: HTTP ${res.statusCode}`);
+          err.httpStatus = res.statusCode;
+          reject(err);
         } else {
-          reject(new Error(`ingestion_endpoint_rejected: HTTP ${res.statusCode}`));
+          // 4xx — permanent client error, do not retry.
+          const err = new Error(`client_error: HTTP ${res.statusCode}`);
+          err.httpStatus = res.statusCode;
+          err.permanent = true;
+          reject(err);
         }
       }
     );
@@ -111,6 +154,21 @@ function _post(payload) {
     req.write(body);
     req.end();
   });
+}
+
+/**
+ * Returns true if the error warrants a retry attempt.
+ * Network errors, timeouts, and server-side 5xx are retryable.
+ * Client errors (4xx) and explicitly flagged permanent errors are not.
+ */
+function _isRetryable(err) {
+  if (err.permanent) return false;
+  if (err.httpStatus && err.httpStatus >= 400 && err.httpStatus < 500) return false;
+  return true;
+}
+
+function _sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
 }
 
 module.exports = { submit, AUDIT_LOG_FILE, INGESTION_URL };


### PR DESCRIPTION
## Summary
Implements CC-HMCP-000004G — Retry / Backoff Semantics for Event Delivery.

This PR adds bounded retry behavior to HTTP event delivery in the emitter transport so transient ingestion failures do not immediately become permanent audit gaps. Delivery remains non-blocking and emitter APIs remain unchanged.

## Context
- ADR-HMCP-002 (PR #22) defines the instrumentation contract
- CC-HMCP-000004B (PR #23) introduced Model C tool invocation emission
- CC-HMCP-000004C (PR #24) added session lifecycle instrumentation
- CC-HMCP-000004D (PR #25) established the HTTP ingestion boundary
- CC-HMCP-000004E (PR #26) added durable ingestion persistence
- CC-HMCP-000004F (PR #27) added readback / inspection
- Delivery failures were still observed and dropped immediately

This PR improves delivery resilience without introducing queues, schema changes, or emitter API changes.

## What This PR Does

### Bounded Retry for HTTP Delivery
- Modifies `src/emitter/transport.js`
- Replaces single-attempt HTTP delivery with:
  - `_postWithRetry()`
  - `_attemptDelivery()`
- Adds `_isRetryable()` classifier to distinguish transient vs permanent delivery failures

### Retry Policy
| Parameter | Value |
|----------|-------|
| Max attempts | 3 total (1 initial + 2 retries) |
| Delay between attempts | 500ms fixed |
| Retry-eligible failures | network errors, timeouts, HTTP 5xx |
| Non-retryable failures | HTTP 4xx |

### Delivery Semantics
- Successful retry counts as successful delivery
- Final exhausted failure is recorded through the existing `failure-observer`
- Caller behavior remains unchanged:
  - tool/session execution never fails due to event delivery failure
  - `submit()` API remains unchanged

## Validation

### Scenario 1 — Immediate Success
- First attempt returned HTTP 200
- No retry occurred
- No caller-visible error

### Scenario 2 — Transient Failure, Then Recovery
- First attempt returned HTTP 500
- Retry triggered after 500ms
- Second attempt returned HTTP 200
- Delivery succeeded
- Recovery logged via `emitter-retry-success`
- Caller unaffected

### Scenario 3 — Retry Budget Exhausted
- All 3 attempts failed (`ECONNREFUSED`)
- Retries occurred at 500ms intervals
- Final failure recorded via `failure-observer`
- Attempts count included in failure record
- Caller still completed normally

## ADR Alignment

This implementation remains aligned with ADR-HMCP-002:

- ✅ bounded retry behavior
- ✅ non-blocking emission semantics
- ✅ final failures remain observable
- ✅ no emitter API change
- ✅ no schema change
- ✅ no queueing system introduced

Not included in this slice:
- ❌ durable client-side retry storage
- ❌ deduplication
- ❌ batching
- ❌ exactly-once delivery
- ❌ jitter/backoff tuning
- ❌ authentication

## Visibility Gap Impact

| Gap | Status |
|-----|--------|
| VG-HMCP-000002 — Tool Invocation Visibility | ✅ Resolved |
| VG-HMCP-000004 — Session Lifecycle Visibility | ✅ Resolved |
| VG-HMCP-000003 — Secret Retrieval Path Visibility | ⚠️ Unchanged |
| VG-HMCP-000001 — Keeper Non-Interactive Retrieval | ❌ Unchanged |

## Limitations (Intentional)

- At-least-once delivery risk
  - a retry may duplicate an event if the server processed an earlier attempt but responded with failure
- No deduplication
  - ingestion boundary does not yet collapse duplicates
- No jitter
  - concurrent retries use the same 500ms delay
- Retry depends on process lifetime
  - short-lived callers may exit before retries complete
- No durable retry queue
  - failures beyond in-process retry budget remain audit gaps

## Consequences

### Positive
- Reduces audit gaps from transient ingestion failures
- Preserves ADR-compliant non-blocking behavior
- Improves resilience without changing platform shape
- Keeps retry logic isolated to the transport layer

### Tradeoffs
- Delivery is still best-effort, not guaranteed
- Duplicate persistence becomes possible under retry
- In-process retry cannot survive caller termination

## Next Steps

Likely follow-on slices:
- **CC-HMCP-000004H — Ingestion Deduplication / Event Identity**
- or **CC-HMCP-000004H — Ingestion Boundary Authentication**

Potential future enhancements:
- jittered backoff
- durable retry queue
- delivery metrics
- duplicate suppression via `event_id`

## Notes

- No public emitter API changes
- No schema modifications introduced
- No ingestion server changes required for this slice

---

This PR upgrades event delivery from single-attempt best effort to bounded transient-failure recovery, improving resilience while preserving the Phase 2 architecture.