### PR TITLE
CC-HMCP-000005B: Add live GitHub MCP validation tooling for dude-mcp-01

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ audit-log/
 
 # Ingestion boundary persistence store (server-side — not committed)
 ingestion-store/
+
+# Validation run logs (runtime artifacts — not committed)
+validate-mcp.stderr.log

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
     "demo": "node src/emitter/demo.js",
     "demo:session": "node src/emitter/demo-session.js",
     "demo:github": "MCP_TRANSPORT=demo node src/mcp-client/demo-github-session.js",
-    "validate": "node tests/validate-mcp-transport.js"
+    "discover": "node src/mcp-client/discover-tools.js",
+    "validate": "node tests/validate-mcp-transport.js",
+    "validate:github": "bash tests/validate-real-github-mcp.sh"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0"

--- a/src/mcp-client/demo-github-session.js
+++ b/src/mcp-client/demo-github-session.js
@@ -13,6 +13,10 @@
 //   Real mode (requires Docker + GitHub PAT on dude-mcp-01 or equivalent):
 //     GITHUB_PERSONAL_ACCESS_TOKEN=<pat> node src/mcp-client/demo-github-session.js
 //
+// Tool names in real mode are resolved from the server at runtime (see TOOL_NAMES below).
+// Override them via env vars if the live server uses different names:
+//   TOOL_NAME_ME=get_me TOOL_NAME_SEARCH=search_repositories
+//
 // Audit events are delivered to EVENT_INGESTION_URL if set, otherwise written
 // to audit-log/tool-invocations.jsonl (JSONL fallback).
 //
@@ -24,27 +28,35 @@
 const { createTransport } = require('./transport-factory');
 const { runMcpSession } = require('./session-runner');
 
+// Tool names for the real GitHub MCP server.
+// Overridable via env in case the live server exposes different names.
+const TOOL_NAMES = {
+  me: process.env.TOOL_NAME_ME || 'get_me',
+  search: process.env.TOOL_NAME_SEARCH || 'search_repositories'
+};
+
 const SESSION_CONTEXT = {
   projectId: 'home-mcp-lab',
-  agentId: 'cc-hmcp-000005a',
+  agentId: 'cc-hmcp-000005b',
   mcpServer: 'github-mcp-server',
-  initiatingContext: 'CC-HMCP-000005A'
+  initiatingContext: 'CC-HMCP-000005B'
 };
 
 async function main() {
   const mode = process.env.MCP_TRANSPORT || 'github';
   console.log(`[demo] Starting GitHub MCP session  transport=${mode}`);
+  console.log(`[demo] Tools: me=${TOOL_NAMES.me}  search=${TOOL_NAMES.search}`);
 
   const transport = createTransport(mode);
 
   await runMcpSession(transport, SESSION_CONTEXT, async ({ callTool }) => {
     // Tool call 1: get authenticated user
-    const me = await callTool('get_me', {});
-    console.log('[demo] get_me result:', JSON.stringify(me).slice(0, 200));
+    const me = await callTool(TOOL_NAMES.me, {});
+    console.log(`[demo] ${TOOL_NAMES.me} result:`, JSON.stringify(me).slice(0, 200));
 
     // Tool call 2: search repositories
-    const repos = await callTool('search_repositories', { query: 'user:@me', per_page: 3 });
-    console.log('[demo] search_repositories result:', JSON.stringify(repos).slice(0, 200));
+    const repos = await callTool(TOOL_NAMES.search, { query: 'user:@me', per_page: 3 });
+    console.log(`[demo] ${TOOL_NAMES.search} result:`, JSON.stringify(repos).slice(0, 200));
   });
 
   const target = process.env.EVENT_INGESTION_URL

--- a/src/mcp-client/discover-tools.js
+++ b/src/mcp-client/discover-tools.js
@@ -1,0 +1,92 @@
+'use strict';
+
+// Tool discovery utility for the real GitHub MCP server.
+//
+// Connects to the MCP server, lists all available tools (name + description),
+// and optionally runs a single test tool call to validate connectivity.
+//
+// Usage:
+//   GITHUB_PERSONAL_ACCESS_TOKEN=<pat> node src/mcp-client/discover-tools.js
+//
+// Output:
+//   Tool list to stdout (JSON)
+//   Connection lifecycle to stderr
+//
+// Flags:
+//   --probe   Run a quick test tool call (uses first available tool with no required args)
+//   --json    Output tools as JSON array (default: human-readable table)
+
+const path = require('path');
+const { Client } = require('@modelcontextprotocol/sdk/client');
+const _sdkClientDir = path.dirname(require.resolve('@modelcontextprotocol/sdk/client'));
+const { StdioClientTransport } = require(path.join(_sdkClientDir, 'stdio'));
+
+const COMMAND = process.env.GITHUB_MCP_COMMAND || 'docker';
+const ARGS = process.env.GITHUB_MCP_ARGS
+  ? JSON.parse(process.env.GITHUB_MCP_ARGS)
+  : ['run', '-i', '--rm', '-e', 'GITHUB_PERSONAL_ACCESS_TOKEN', 'ghcr.io/github/github-mcp-server'];
+
+const MCP_CLIENT_INFO = { name: 'home-mcp-lab-discovery', version: '0.1.0' };
+
+const flags = new Set(process.argv.slice(2));
+const doProbe = flags.has('--probe');
+const doJson = flags.has('--json');
+
+async function main() {
+  process.stderr.write(`[discover] Connecting: ${COMMAND} ${ARGS.join(' ')}\n`);
+
+  const transport = new StdioClientTransport({ command: COMMAND, args: ARGS, env: process.env });
+  const client = new Client(MCP_CLIENT_INFO, { capabilities: {} });
+
+  try {
+    await client.connect(transport);
+    process.stderr.write('[discover] Connected\n');
+
+    const { tools } = await client.listTools();
+
+    if (doJson) {
+      console.log(JSON.stringify(tools, null, 2));
+    } else {
+      console.log(`\nGitHub MCP Server — ${tools.length} tool(s) available:\n`);
+      for (const t of tools) {
+        const req = t.inputSchema && t.inputSchema.required ? t.inputSchema.required.join(', ') : '(none)';
+        console.log(`  ${t.name}`);
+        console.log(`    description : ${(t.description || '').slice(0, 120)}`);
+        console.log(`    required    : ${req}`);
+        console.log();
+      }
+    }
+
+    if (doProbe) {
+      // Find a tool with no required args to call as a connection probe.
+      const probeTarget = tools.find(t =>
+        !t.inputSchema || !t.inputSchema.required || t.inputSchema.required.length === 0
+      );
+      if (probeTarget) {
+        process.stderr.write(`[discover] Probing tool: ${probeTarget.name}\n`);
+        try {
+          const result = await client.callTool({ name: probeTarget.name, arguments: {} });
+          const summary = JSON.stringify(result).slice(0, 200);
+          process.stderr.write(`[discover] Probe success: ${summary}\n`);
+          console.log(`\nProbe result (${probeTarget.name}):`);
+          console.log(JSON.stringify(result, null, 2));
+        } catch (err) {
+          process.stderr.write(`[discover] Probe failed: ${err.message}\n`);
+        }
+      } else {
+        process.stderr.write('[discover] No zero-arg tool found for probe\n');
+      }
+    }
+
+  } finally {
+    try {
+      await client.close();
+      process.stderr.write('[discover] Disconnected\n');
+    } catch (_) {}
+  }
+}
+
+main().catch(err => {
+  process.stderr.write(`[discover] Fatal: ${err.message}\n`);
+  process.exit(1);
+});

--- a/tests/validate-real-github-mcp.sh
+++ b/tests/validate-real-github-mcp.sh
@@ -1,0 +1,327 @@
+#!/usr/bin/env bash
+# validate-real-github-mcp.sh
+#
+# Full validation of the real GitHub MCP transport on dude-mcp-01.
+# Run on dude-mcp-01 after pulling the repo and running npm install.
+#
+# Prerequisites:
+#   - Docker installed and running
+#   - GITHUB_PERSONAL_ACCESS_TOKEN set in the calling shell environment
+#   - Repo cloned/pulled at /home/drake/projects/home-mcp-lab
+#   - npm install run in the repo root
+#
+# Usage:
+#   cd /home/drake/projects/home-mcp-lab
+#   GITHUB_PERSONAL_ACCESS_TOKEN=<pat> bash tests/validate-real-github-mcp.sh
+#
+# Optional: also validate event pipeline through ingestion server
+#   GITHUB_PERSONAL_ACCESS_TOKEN=<pat> \
+#   EVENT_INGESTION_URL=http://localhost:4318/events \
+#   bash tests/validate-real-github-mcp.sh
+#
+# Output:
+#   Validation log to stdout
+#   MCP and emitter traces to stderr
+#   Summary at end: PASS / FAIL per check
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+PASS=0
+FAIL=0
+RESULTS=()
+
+pass() { PASS=$((PASS+1)); RESULTS+=("[PASS] $1"); echo "  [PASS] $1"; }
+fail() { FAIL=$((FAIL+1)); RESULTS+=("[FAIL] $1"); echo "  [FAIL] $1"; }
+section() { echo; echo "── $1 ──"; }
+
+# ── 0. Pre-flight ─────────────────────────────────────────────────────────────
+
+section "0. Pre-flight"
+
+if [ -z "${GITHUB_PERSONAL_ACCESS_TOKEN:-}" ]; then
+  echo "ERROR: GITHUB_PERSONAL_ACCESS_TOKEN is not set."
+  echo "Usage: GITHUB_PERSONAL_ACCESS_TOKEN=<pat> bash tests/validate-real-github-mcp.sh"
+  exit 1
+fi
+echo "  GITHUB_PERSONAL_ACCESS_TOKEN: set (not logged)"
+
+if ! command -v docker &>/dev/null; then
+  echo "ERROR: Docker not found. Install Docker and retry."
+  exit 1
+fi
+if ! docker info &>/dev/null; then
+  echo "ERROR: Docker daemon is not running."
+  exit 1
+fi
+echo "  Docker: running"
+
+if [ ! -f "package.json" ] || [ ! -d "node_modules/@modelcontextprotocol/sdk" ]; then
+  echo "  Running npm install..."
+  npm install
+fi
+echo "  Dependencies: ok"
+
+# ── 1. Docker image pull ──────────────────────────────────────────────────────
+
+section "1. Pull GitHub MCP server image"
+
+if docker pull ghcr.io/github/github-mcp-server 2>&1 | tail -3; then
+  pass "Docker image pulled: ghcr.io/github/github-mcp-server"
+else
+  fail "Docker image pull failed"
+  echo "Cannot continue without the image." && exit 1
+fi
+
+# ── 2. Transport unit tests (no network) ─────────────────────────────────────
+
+section "2. Unit validation (demo transport)"
+
+if node tests/validate-mcp-transport.js 2>/dev/null | tail -3; then
+  pass "validate-mcp-transport.js: all tests passed"
+else
+  fail "validate-mcp-transport.js: one or more tests failed"
+fi
+
+# ── 3. Tool discovery ─────────────────────────────────────────────────────────
+
+section "3. Tool discovery (real GitHub MCP server)"
+
+TOOLS_JSON=$(mktemp /tmp/mcp-tools-XXXXXXXX.json)
+
+if node src/mcp-client/discover-tools.js --json 2>>"$REPO_ROOT/validate-mcp.stderr.log" > "$TOOLS_JSON"; then
+  TOOL_COUNT=$(python3 -c "import json; print(len(json.load(open('$TOOLS_JSON'))))" 2>/dev/null || echo 0)
+  pass "Tool discovery: ${TOOL_COUNT} tools returned"
+  echo
+  echo "  Tool list:"
+  python3 -c "
+import json
+tools = json.load(open('$TOOLS_JSON'))
+for t in sorted(tools, key=lambda x: x['name']):
+    req = ', '.join(t.get('inputSchema',{}).get('required',[]) or [])
+    print(f'    {t[\"name\"]:40s}  required: [{req}]')
+"
+  echo
+
+  # Extract key tool names for use in subsequent steps
+  GET_ME=$(python3 -c "
+import json; tools=json.load(open('$TOOLS_JSON'))
+candidates = [t['name'] for t in tools if 'me' in t['name'].lower() or 'user' in t['name'].lower() and 'authenticated' in t.get('description','').lower()]
+print(candidates[0] if candidates else 'get_me')
+" 2>/dev/null || echo "get_me")
+  SEARCH=$(python3 -c "
+import json; tools=json.load(open('$TOOLS_JSON'))
+candidates = [t['name'] for t in tools if 'search' in t['name'].lower() and 'repo' in t['name'].lower()]
+print(candidates[0] if candidates else 'search_repositories')
+" 2>/dev/null || echo "search_repositories")
+  echo "  Resolved tool names: me=${GET_ME}  search=${SEARCH}"
+else
+  fail "Tool discovery failed — check validate-mcp.stderr.log"
+  GET_ME="get_me"
+  SEARCH="search_repositories"
+fi
+
+# ── 4. Connection probe ───────────────────────────────────────────────────────
+
+section "4. Connection probe (real GitHub MCP server)"
+
+if node src/mcp-client/discover-tools.js --probe 2>>"$REPO_ROOT/validate-mcp.stderr.log" | head -20; then
+  pass "Connection probe: successful"
+else
+  fail "Connection probe: failed — check validate-mcp.stderr.log"
+fi
+
+# ── 5. Instrumented session ───────────────────────────────────────────────────
+
+section "5. Instrumented session (real transport, JSONL fallback)"
+
+SESSION_LOG=$(mktemp /tmp/mcp-session-XXXXXXXX.log)
+
+# Run the instrumented demo session with real transport
+# Events go to JSONL fallback if EVENT_INGESTION_URL is not set
+JSONL_BEFORE=0
+if [ -f "audit-log/tool-invocations.jsonl" ]; then
+  JSONL_BEFORE=$(wc -l < "audit-log/tool-invocations.jsonl")
+fi
+
+if TOOL_NAME_ME="$GET_ME" TOOL_NAME_SEARCH="$SEARCH" \
+   node src/mcp-client/demo-github-session.js \
+   > "$SESSION_LOG" 2>>"$REPO_ROOT/validate-mcp.stderr.log"; then
+  pass "Instrumented session: completed without error"
+else
+  fail "Instrumented session: exited with error"
+fi
+
+cat "$SESSION_LOG"
+
+# Count new events appended to JSONL
+if [ -f "audit-log/tool-invocations.jsonl" ]; then
+  JSONL_AFTER=$(wc -l < "audit-log/tool-invocations.jsonl")
+  NEW_EVENTS=$((JSONL_AFTER - JSONL_BEFORE))
+  if [ "$NEW_EVENTS" -ge 4 ]; then
+    pass "Audit events: ${NEW_EVENTS} new events emitted (expected ≥4)"
+  else
+    fail "Audit events: only ${NEW_EVENTS} new events (expected ≥4: session.start + 2×tool.invocation + session.end)"
+  fi
+else
+  fail "Audit events: audit-log/tool-invocations.jsonl not found"
+fi
+
+# ── 6. Session trace verification ────────────────────────────────────────────
+
+section "6. Session trace verification"
+
+if [ -f "audit-log/tool-invocations.jsonl" ] && [ "$NEW_EVENTS" -ge 1 ] 2>/dev/null; then
+  # Extract correlation_id from the latest session.start event
+  CORR_ID=$(tail -"${NEW_EVENTS}" audit-log/tool-invocations.jsonl | \
+    python3 -c "
+import sys, json
+for line in sys.stdin:
+    e = json.loads(line.strip())
+    if e.get('event_type') == 'session.start':
+        print(e['correlation_id'])
+        break
+" 2>/dev/null || echo "")
+
+  if [ -n "$CORR_ID" ]; then
+    pass "session.start event found: correlation_id=${CORR_ID}"
+
+    # Count events with this correlation_id
+    TRACE_COUNT=$(tail -"${NEW_EVENTS}" audit-log/tool-invocations.jsonl | \
+      python3 -c "
+import sys, json
+n=0
+for line in sys.stdin:
+    e=json.loads(line.strip())
+    if e.get('correlation_id') == '${CORR_ID}':
+        n+=1
+print(n)
+" 2>/dev/null || echo 0)
+
+    HAS_END=$(tail -"${NEW_EVENTS}" audit-log/tool-invocations.jsonl | \
+      python3 -c "
+import sys, json
+for line in sys.stdin:
+    e=json.loads(line.strip())
+    if e.get('event_type') == 'session.end' and e.get('correlation_id') == '${CORR_ID}':
+        print('yes')
+        break
+" 2>/dev/null || echo "no")
+
+    HAS_TOOL=$(tail -"${NEW_EVENTS}" audit-log/tool-invocations.jsonl | \
+      python3 -c "
+import sys, json
+for line in sys.stdin:
+    e=json.loads(line.strip())
+    if e.get('event_type') == 'tool.invocation' and e.get('correlation_id') == '${CORR_ID}':
+        print('yes')
+        break
+" 2>/dev/null || echo "no")
+
+    [ "$HAS_END" = "yes" ] && pass "session.end event found for correlation_id" || fail "session.end event missing"
+    [ "$HAS_TOOL" = "yes" ] && pass "tool.invocation event found for correlation_id" || fail "tool.invocation event missing"
+    echo "  Trace: ${TRACE_COUNT} events under correlation_id=${CORR_ID}"
+
+    # Print the trace
+    echo
+    echo "  Event trace:"
+    tail -"${NEW_EVENTS}" audit-log/tool-invocations.jsonl | \
+      python3 -c "
+import sys, json
+for line in sys.stdin:
+    e = json.loads(line.strip())
+    if e.get('correlation_id') == '${CORR_ID}':
+        print(f'    [{e[\"event_type\"]:20s}] action={e[\"action\"]:30s} status={e[\"status\"]}')
+"
+  else
+    fail "Could not extract correlation_id from session.start event"
+  fi
+fi
+
+# ── 7. Ingestion server pipeline (optional) ───────────────────────────────────
+
+section "7. Ingestion server pipeline"
+
+if [ -n "${EVENT_INGESTION_URL:-}" ]; then
+  echo "  EVENT_INGESTION_URL=${EVENT_INGESTION_URL}"
+  HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" "${EVENT_INGESTION_URL%/events}/events?limit=1" 2>/dev/null || echo "000")
+  if [ "$HTTP_STATUS" = "200" ]; then
+    pass "Ingestion server reachable at ${EVENT_INGESTION_URL}"
+    # Re-run session with ingestion server active
+    if TOOL_NAME_ME="$GET_ME" TOOL_NAME_SEARCH="$SEARCH" \
+       EVENT_INGESTION_URL="$EVENT_INGESTION_URL" \
+       node src/mcp-client/demo-github-session.js \
+       2>>"$REPO_ROOT/validate-mcp.stderr.log" >/dev/null; then
+      pass "Instrumented session with ingestion pipeline: completed"
+      # Wait briefly for async delivery
+      sleep 1
+      COUNT=$(curl -s "${EVENT_INGESTION_URL%/events}/events?limit=10" | \
+        python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('count',0))" 2>/dev/null || echo 0)
+      pass "Events readable from ingestion server: count=${COUNT}"
+    else
+      fail "Instrumented session with ingestion pipeline: failed"
+    fi
+  else
+    echo "  Ingestion server not reachable (HTTP ${HTTP_STATUS}) — skipping pipeline check"
+    echo "  To include this check: start the ingestion server first:"
+    echo "    PORT=4318 node src/ingestion/server.js &"
+  fi
+else
+  echo "  EVENT_INGESTION_URL not set — skipping ingestion pipeline check"
+  echo "  To include: EVENT_INGESTION_URL=http://localhost:4318/events bash $0"
+fi
+
+# ── 8. Schema conformity spot-check ──────────────────────────────────────────
+
+section "8. Schema conformity spot-check"
+
+if [ -f "audit-log/tool-invocations.jsonl" ] && [ "${NEW_EVENTS:-0}" -ge 1 ]; then
+  INVALID=$(tail -"${NEW_EVENTS}" audit-log/tool-invocations.jsonl | \
+    python3 -c "
+import sys, json
+required = ['schema_version','event_id','event_type','timestamp','platform',
+            'project_id','agent_id','mcp_server','action','status','correlation_id','metadata']
+invalid = 0
+for line in sys.stdin:
+    line = line.strip()
+    if not line: continue
+    try:
+        e = json.loads(line)
+        for f in required:
+            if f not in e:
+                print(f'Missing field: {f} in event_id={e.get(\"event_id\",\"?\")}')
+                invalid += 1
+    except Exception as ex:
+        print(f'Parse error: {ex}')
+        invalid += 1
+print(f'invalid_count={invalid}')
+" 2>/dev/null || echo "invalid_count=check_failed")
+
+  if echo "$INVALID" | grep -q "invalid_count=0"; then
+    pass "Schema conformity: all ${NEW_EVENTS} new events have required fields"
+  else
+    fail "Schema conformity: one or more events missing required fields"
+    echo "$INVALID"
+  fi
+fi
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+
+echo
+echo "══════════════════════════════════════════"
+echo "Validation Summary"
+echo "══════════════════════════════════════════"
+for r in "${RESULTS[@]}"; do echo "  $r"; done
+echo
+echo "  Passed: ${PASS}  Failed: ${FAIL}"
+echo
+
+# Cleanup
+rm -f "$TOOLS_JSON" "$SESSION_LOG" 2>/dev/null
+
+if [ "$FAIL" -gt 0 ]; then
+  echo "  Full stderr log: ${REPO_ROOT}/validate-mcp.stderr.log"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Implements CC-HMCP-000005B by adding the tooling and scripts needed to validate the real GitHub MCP transport on dude-mcp-01.

Because Docker is unavailable on the current development machine and SSH access to dude-mcp-01 requires interactive passphrase entry, the live validation itself could not be executed here. This PR delivers the validation artifacts, discovery tooling, and operator workflow required to run the real check directly on dude-mcp-01.

## What changed

- Added real-tool discovery utility for the GitHub MCP server
- Updated the demo GitHub session entry point to support live-resolved tool names
- Added a full validation script for running end-to-end checks on dude-mcp-01
- Added package scripts for discovery and validation flows
- Added runtime log artifact ignore rule

## Files

- `src/mcp-client/discover-tools.js`
- `src/mcp-client/demo-github-session.js`
- `tests/validate-real-github-mcp.sh`
- `package.json`
- `.gitignore`

## Why this change

The transport implementation from CC-HMCP-000005A is merged, but the remaining gap is operational proof against a live GitHub MCP server on the actual host environment.

This PR prepares that proof path by:
- discovering the real tool list from the live server
- avoiding hard-coded assumptions about tool names
- packaging validation into a repeatable operator script
- supporting optional ingestion verification during the same run

## Validation workflow included

The validation script supports these checks:

- pre-flight environment checks
- unit validation for the demo transport
- live tool discovery
- real connection probe
- instrumented session lifecycle validation
- session trace correlation checks
- optional ingestion pipeline verification
- schema conformity spot checks

## Architectural notes

This remains validation-focused and avoids unnecessary transport refactoring.

Important design choices:
- live tool names are resolved from the server instead of assumed
- tool selection can be overridden with environment variables
- no secrets are stored in source control
- the operator runbook remains externalized to the host where real validation is actually possible

## Known limitations

- Real validation was not executed in this environment
- Docker is not available on the current machine
- SSH to dude-mcp-01 is not currently automatable from this machine because it requires interactive passphrase entry
- VG-HMCP-000002 and VG-HMCP-000004 remain unconfirmed until the operator runs the validation and returns evidence

## Operator next step

Run the validation directly on dude-mcp-01 with a valid GitHub PAT and, optionally, a live ingestion endpoint. Capture:
- discovered tool names
- successful session trace
- ingestion results
- any errors or mismatches

## Expected outcome after operator run

Once the live validation results are returned, we can:
- confirm or refine the GitHub MCP tool mapping
- assess whether VG-HMCP-000002 can be narrowed or closed
- assess whether VG-HMCP-000004 can be narrowed or closed
- decide whether the next task is VG closure, PAT retrieval work, or control-layer follow-up