### PR TITLE
CC-HMCP-000005C: Fix live GitHub MCP validation classification

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "demo:session": "node src/emitter/demo-session.js",
     "demo:github": "MCP_TRANSPORT=demo node src/mcp-client/demo-github-session.js",
     "discover": "node src/mcp-client/discover-tools.js",
+    "resolve-probes": "node src/mcp-client/resolve-probe-tools.js",
     "validate": "node tests/validate-mcp-transport.js",
     "validate:github": "bash tests/validate-real-github-mcp.sh"
   },

--- a/src/mcp-client/discover-tools.js
+++ b/src/mcp-client/discover-tools.js
@@ -13,13 +13,14 @@
 //   Connection lifecycle to stderr
 //
 // Flags:
-//   --probe   Run a quick test tool call (uses first available tool with no required args)
+//   --probe   Run the identity probe tool (get_me or safe fallback)
 //   --json    Output tools as JSON array (default: human-readable table)
 
 const path = require('path');
 const { Client } = require('@modelcontextprotocol/sdk/client');
 const _sdkClientDir = path.dirname(require.resolve('@modelcontextprotocol/sdk/client'));
 const { StdioClientTransport } = require(path.join(_sdkClientDir, 'stdio'));
+const { selectIdentityProbe, classifyToolResult } = require('./tool-selector');
 
 const COMMAND = process.env.GITHUB_MCP_COMMAND || 'docker';
 const ARGS = process.env.GITHUB_MCP_ARGS
@@ -58,23 +59,38 @@ async function main() {
     }
 
     if (doProbe) {
-      // Find a tool with no required args to call as a connection probe.
-      const probeTarget = tools.find(t =>
-        !t.inputSchema || !t.inputSchema.required || t.inputSchema.required.length === 0
-      );
-      if (probeTarget) {
-        process.stderr.write(`[discover] Probing tool: ${probeTarget.name}\n`);
-        try {
-          const result = await client.callTool({ name: probeTarget.name, arguments: {} });
-          const summary = JSON.stringify(result).slice(0, 200);
-          process.stderr.write(`[discover] Probe success: ${summary}\n`);
-          console.log(`\nProbe result (${probeTarget.name}):`);
-          console.log(JSON.stringify(result, null, 2));
-        } catch (err) {
-          process.stderr.write(`[discover] Probe failed: ${err.message}\n`);
-        }
+      const probeName = selectIdentityProbe(tools);
+      if (!probeName) {
+        process.stderr.write('[discover] No safe identity probe tool found — cannot probe\n');
+        process.exit(1);
+      }
+
+      process.stderr.write(`[discover] Probing tool: ${probeName}\n`);
+
+      let result = null;
+      let callErr = null;
+      try {
+        result = await client.callTool({ name: probeName, arguments: {} });
+      } catch (err) {
+        callErr = err;
+      }
+
+      const classification = classifyToolResult(result, callErr);
+      process.stderr.write(`[discover] Probe classification: ${classification}\n`);
+
+      if (classification === 'mcp_error') {
+        process.stderr.write(`[discover] MCP transport error: ${callErr.message}\n`);
+        process.exit(1);
+      } else if (classification === 'auth_failure') {
+        const summary = JSON.stringify(result).slice(0, 200);
+        process.stderr.write(`[discover] GitHub API auth failure (MCP session OK): ${summary}\n`);
+        // Exit 2 signals auth failure distinct from MCP failure (exit 1)
+        process.exit(2);
       } else {
-        process.stderr.write('[discover] No zero-arg tool found for probe\n');
+        const summary = JSON.stringify(result).slice(0, 200);
+        process.stderr.write(`[discover] Probe success: ${summary}\n`);
+        console.log(`\nProbe result (${probeName}):`);
+        console.log(JSON.stringify(result, null, 2));
       }
     }
 

--- a/src/mcp-client/resolve-probe-tools.js
+++ b/src/mcp-client/resolve-probe-tools.js
@@ -1,0 +1,56 @@
+'use strict';
+
+// Resolves safe probe tool names from a live GitHub MCP server.
+// Outputs a single JSON object to stdout — used by validate-real-github-mcp.sh.
+//
+// Output format:
+//   {"identity": "get_me", "search": "search_repositories"}
+//
+// Exit codes:
+//   0 — both tools resolved
+//   1 — connection or discovery failure
+//
+// Usage (in shell):
+//   PROBE_TOOLS=$(GITHUB_PERSONAL_ACCESS_TOKEN=<pat> node src/mcp-client/resolve-probe-tools.js)
+//   IDENTITY=$(echo "$PROBE_TOOLS" | python3 -c "import sys,json; print(json.load(sys.stdin)['identity'])")
+//   SEARCH=$(echo  "$PROBE_TOOLS" | python3 -c "import sys,json; print(json.load(sys.stdin)['search'])")
+
+const path = require('path');
+const { Client } = require('@modelcontextprotocol/sdk/client');
+const _sdkClientDir = path.dirname(require.resolve('@modelcontextprotocol/sdk/client'));
+const { StdioClientTransport } = require(path.join(_sdkClientDir, 'stdio'));
+const { selectIdentityProbe, selectSearchProbe } = require('./tool-selector');
+
+const COMMAND = process.env.GITHUB_MCP_COMMAND || 'docker';
+const ARGS = process.env.GITHUB_MCP_ARGS
+  ? JSON.parse(process.env.GITHUB_MCP_ARGS)
+  : ['run', '-i', '--rm', '-e', 'GITHUB_PERSONAL_ACCESS_TOKEN', 'ghcr.io/github/github-mcp-server'];
+
+const MCP_CLIENT_INFO = { name: 'home-mcp-lab-resolver', version: '0.1.0' };
+
+async function main() {
+  const transport = new StdioClientTransport({ command: COMMAND, args: ARGS, env: process.env });
+  const client = new Client(MCP_CLIENT_INFO, { capabilities: {} });
+
+  try {
+    await client.connect(transport);
+    const { tools } = await client.listTools();
+
+    const identity = selectIdentityProbe(tools);
+    const search = selectSearchProbe(tools);
+
+    if (!identity) {
+      process.stderr.write('[resolve-probe-tools] No safe identity probe tool found\n');
+      process.exit(1);
+    }
+
+    console.log(JSON.stringify({ identity, search: search || null }));
+  } finally {
+    try { await client.close(); } catch (_) {}
+  }
+}
+
+main().catch(err => {
+  process.stderr.write(`[resolve-probe-tools] Fatal: ${err.message}\n`);
+  process.exit(1);
+});

--- a/src/mcp-client/tool-selector.js
+++ b/src/mcp-client/tool-selector.js
@@ -1,0 +1,188 @@
+'use strict';
+
+// Tool selection logic for safe validation probes.
+//
+// Provides deterministic, safety-first selection of representative tools
+// from a GitHub MCP server tool list. Never selects mutation tools as probes.
+//
+// Exported:
+//   selectIdentityProbe(tools)  — safe read-only identity tool
+//   selectSearchProbe(tools)    — safe read-only search/list tool
+//   classifyToolResult(result, err) — distinguish MCP error, auth failure, and success
+
+// ── Preference lists ──────────────────────────────────────────────────────────
+
+// Ordered preference for identity/auth probe.
+// These are safe read-only, zero-or-few-required-arg tools on GitHub MCP server.
+const IDENTITY_PROBE_PREFERENCE = [
+  'get_me',
+  'get_authenticated_user',
+  'get_teams',
+  'list_teams',
+  'list_org_teams'
+];
+
+// Ordered preference for search/list probe.
+const SEARCH_PROBE_PREFERENCE = [
+  'search_repositories',
+  'list_repositories',
+  'list_repos',
+  'search_code',
+  'search_issues'
+];
+
+// ── Mutation denylist ─────────────────────────────────────────────────────────
+
+// Patterns that indicate a tool mutates GitHub state.
+// A tool whose name contains any of these terms is never selected as a probe.
+const MUTATION_PATTERNS = [
+  /^create_/,
+  /^delete_/,
+  /^update_/,
+  /^merge_/,
+  /^add_/,
+  /^remove_/,
+  /^edit_/,
+  /^close_/,
+  /^reopen_/,
+  /^comment_/,
+  /_comment/,
+  /^review_/,
+  /_review/,
+  /^approve_/,
+  /^submit_/,
+  /^push_/,
+  /^fork_/,
+  /^star_/,
+  /^unstar_/,
+  /^assign_/,
+  /^unassign_/,
+  /^dismiss_/,
+  /^enable_/,
+  /^disable_/,
+  /^rename_/,
+  /^transfer_/,
+  /^archive_/,
+  /^lock_/,
+  /^unlock_/,
+  /^request_/,
+  /^invite_/,
+  /^publish_/,
+  /^draft_/,
+  /^tag_/,
+  /^release_/,
+  /^pin_/,
+  /^unpin_/,
+  /^mark_/,
+  /^set_/,
+  /^clear_/,
+  /^trigger_/
+];
+
+function isMutationTool(toolName) {
+  return MUTATION_PATTERNS.some(p => p.test(toolName));
+}
+
+function hasNoRequiredArgs(tool) {
+  const required = tool.inputSchema && tool.inputSchema.required;
+  return !required || required.length === 0;
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+/**
+ * Select a safe identity probe tool from the server's tool list.
+ *
+ * Preference order:
+ *   1. First match from IDENTITY_PROBE_PREFERENCE (exact name, any arg shape)
+ *   2. First zero-arg, non-mutation tool not already in SEARCH_PROBE_PREFERENCE
+ *
+ * Returns null if no safe tool can be identified — caller must handle explicitly.
+ *
+ * @param {Array<{name: string, inputSchema?: object}>} tools
+ * @returns {string|null}
+ */
+function selectIdentityProbe(tools) {
+  const names = new Set(tools.map(t => t.name));
+
+  // Step 1: explicit preference list
+  for (const preferred of IDENTITY_PROBE_PREFERENCE) {
+    if (names.has(preferred)) return preferred;
+  }
+
+  // Step 2: any safe read-only zero-arg tool not in search preference list
+  const searchSet = new Set(SEARCH_PROBE_PREFERENCE);
+  const fallback = tools.find(t =>
+    !isMutationTool(t.name) &&
+    hasNoRequiredArgs(t) &&
+    !searchSet.has(t.name)
+  );
+
+  return fallback ? fallback.name : null;
+}
+
+/**
+ * Select a safe search/list probe tool from the server's tool list.
+ *
+ * Preference order:
+ *   1. First match from SEARCH_PROBE_PREFERENCE (exact name)
+ *   2. First non-mutation tool whose name starts with 'list_' or 'search_'
+ *
+ * Returns null if no safe tool can be identified.
+ *
+ * @param {Array<{name: string, inputSchema?: object}>} tools
+ * @returns {string|null}
+ */
+function selectSearchProbe(tools) {
+  const names = new Set(tools.map(t => t.name));
+
+  // Step 1: explicit preference list
+  for (const preferred of SEARCH_PROBE_PREFERENCE) {
+    if (names.has(preferred)) return preferred;
+  }
+
+  // Step 2: any list_ or search_ tool that isn't a mutation
+  const fallback = tools.find(t =>
+    !isMutationTool(t.name) &&
+    (t.name.startsWith('list_') || t.name.startsWith('search_'))
+  );
+
+  return fallback ? fallback.name : null;
+}
+
+/**
+ * Classify a tool call result into one of three categories:
+ *   'success'      — tool returned valid data
+ *   'auth_failure' — GitHub API rejected the request (401/403/bad credentials)
+ *   'mcp_error'    — transport or MCP protocol-level error (err was thrown)
+ *
+ * When callTool() throws, pass the error as `err`. When it returns normally,
+ * pass the result as `result` and leave `err` null.
+ *
+ * @param {any} result   — return value from callTool (may be null if err is set)
+ * @param {Error|null} err — caught error from callTool, or null on success
+ * @returns {'success'|'auth_failure'|'mcp_error'}
+ */
+function classifyToolResult(result, err) {
+  if (err) {
+    return 'mcp_error';
+  }
+
+  const text = JSON.stringify(result || '');
+  const lower = text.toLowerCase();
+
+  if (
+    lower.includes('401') ||
+    lower.includes('bad credentials') ||
+    lower.includes('unauthorized') ||
+    lower.includes('403') ||
+    lower.includes('forbidden') ||
+    lower.includes('requires authentication')
+  ) {
+    return 'auth_failure';
+  }
+
+  return 'success';
+}
+
+module.exports = { selectIdentityProbe, selectSearchProbe, classifyToolResult, isMutationTool };

--- a/tests/validate-mcp-transport.js
+++ b/tests/validate-mcp-transport.js
@@ -226,6 +226,132 @@ async function test(name, fn) {
     await t.close(); // safe on unconnected
   });
 
+  // ── 5. Tool selector ─────────────────────────────────────────────────────
+
+  console.log('\n5. Tool selector');
+
+  const { selectIdentityProbe, selectSearchProbe, classifyToolResult, isMutationTool } =
+    require('../src/mcp-client/tool-selector');
+
+  // Helper: build a minimal tool descriptor
+  const tool = (name, required = []) => ({ name, inputSchema: { required } });
+
+  await test('selectIdentityProbe: prefers get_me when present', async () => {
+    const tools = [
+      tool('add_comment_to_pending_review', []),
+      tool('search_repositories', []),
+      tool('get_me', []),
+      tool('list_issues', ['owner', 'repo'])
+    ];
+    assert.strictEqual(selectIdentityProbe(tools), 'get_me');
+  });
+
+  await test('selectIdentityProbe: uses preference-list fallback when get_me absent', async () => {
+    const tools = [
+      tool('search_repositories', []),
+      tool('get_teams', []),
+      tool('list_issues', ['owner', 'repo'])
+    ];
+    assert.strictEqual(selectIdentityProbe(tools), 'get_teams');
+  });
+
+  await test('selectIdentityProbe: never selects a mutation tool', async () => {
+    // Only mutation tools + one search tool available — should return null or search
+    const tools = [
+      tool('create_issue', ['owner', 'repo', 'title']),
+      tool('delete_branch', ['owner', 'repo', 'branch']),
+      tool('add_comment_to_pending_review', []),
+      tool('update_pull_request', ['owner', 'repo']),
+      tool('search_repositories', [])  // search goes to searchProbe, not identityProbe
+    ];
+    const result = selectIdentityProbe(tools);
+    // search_repositories is in SEARCH_PROBE_PREFERENCE, so selectIdentityProbe skips it
+    assert.strictEqual(result, null, 'Expected null when only mutation or search tools available');
+  });
+
+  await test('selectIdentityProbe: returns null when no safe tool exists', async () => {
+    const tools = [
+      tool('create_issue', ['owner', 'repo', 'title']),
+      tool('delete_branch', ['owner', 'repo'])
+    ];
+    assert.strictEqual(selectIdentityProbe(tools), null);
+  });
+
+  await test('selectSearchProbe: prefers search_repositories', async () => {
+    const tools = [
+      tool('list_repos', []),
+      tool('search_repositories', ['query']),
+      tool('get_me', [])
+    ];
+    assert.strictEqual(selectSearchProbe(tools), 'search_repositories');
+  });
+
+  await test('selectSearchProbe: falls back to list_ tool when search_repositories absent', async () => {
+    const tools = [
+      tool('get_me', []),
+      tool('list_issues', ['owner', 'repo']),
+      tool('list_repositories', [])
+    ];
+    assert.strictEqual(selectSearchProbe(tools), 'list_repositories');
+  });
+
+  await test('isMutationTool: identifies mutation tools correctly', async () => {
+    assert.strictEqual(isMutationTool('create_issue'), true);
+    assert.strictEqual(isMutationTool('delete_branch'), true);
+    assert.strictEqual(isMutationTool('add_comment_to_pending_review'), true);
+    assert.strictEqual(isMutationTool('update_pull_request'), true);
+    assert.strictEqual(isMutationTool('get_me'), false);
+    assert.strictEqual(isMutationTool('search_repositories'), false);
+    assert.strictEqual(isMutationTool('list_issues'), false);
+  });
+
+  // ── 6. Tool result classification ─────────────────────────────────────────
+
+  console.log('\n6. Tool result classification');
+
+  await test('classifyToolResult: success on valid data', async () => {
+    assert.strictEqual(
+      classifyToolResult({ login: 'drake', id: 123 }, null),
+      'success'
+    );
+  });
+
+  await test('classifyToolResult: auth_failure on 401 response content', async () => {
+    assert.strictEqual(
+      classifyToolResult({ content: [{ text: 'HTTP 401: Bad credentials' }] }, null),
+      'auth_failure'
+    );
+  });
+
+  await test('classifyToolResult: auth_failure on "Unauthorized" in result', async () => {
+    assert.strictEqual(
+      classifyToolResult({ error: 'Unauthorized — check your token' }, null),
+      'auth_failure'
+    );
+  });
+
+  await test('classifyToolResult: auth_failure on 403 forbidden', async () => {
+    assert.strictEqual(
+      classifyToolResult({ message: '403 Forbidden' }, null),
+      'auth_failure'
+    );
+  });
+
+  await test('classifyToolResult: mcp_error when err is thrown', async () => {
+    assert.strictEqual(
+      classifyToolResult(null, new Error('ECONNREFUSED')),
+      'mcp_error'
+    );
+  });
+
+  await test('classifyToolResult: mcp_error takes priority over result content', async () => {
+    // Even if result has auth-like text, a thrown error is always mcp_error
+    assert.strictEqual(
+      classifyToolResult({ message: '401' }, new Error('transport closed')),
+      'mcp_error'
+    );
+  });
+
   // ── Summary ───────────────────────────────────────────────────────────────
 
   const bar = '─'.repeat(40);

--- a/tests/validate-real-github-mcp.sh
+++ b/tests/validate-real-github-mcp.sh
@@ -2,27 +2,27 @@
 # validate-real-github-mcp.sh
 #
 # Full validation of the real GitHub MCP transport on dude-mcp-01.
-# Run on dude-mcp-01 after pulling the repo and running npm install.
+# Reports results in four separate layers so failures are precisely locatable.
+#
+# Layers:
+#   1 — Container / runtime   (Docker image, Node deps)
+#   2 — MCP session           (connect, tool discovery, probe invocation)
+#   3 — GitHub API auth       (tool result content — 401 vs valid data)
+#   4 — Audit event pipeline  (JSONL fallback OR ingestion server — not both required)
 #
 # Prerequisites:
-#   - Docker installed and running
+#   - Docker installed and running on dude-mcp-01
 #   - GITHUB_PERSONAL_ACCESS_TOKEN set in the calling shell environment
 #   - Repo cloned/pulled at /home/drake/projects/home-mcp-lab
-#   - npm install run in the repo root
 #
 # Usage:
 #   cd /home/drake/projects/home-mcp-lab
 #   GITHUB_PERSONAL_ACCESS_TOKEN=<pat> bash tests/validate-real-github-mcp.sh
 #
-# Optional: also validate event pipeline through ingestion server
-#   GITHUB_PERSONAL_ACCESS_TOKEN=<pat> \
+# With ingestion server:
+#   PORT=4318 node src/ingestion/server.js &
 #   EVENT_INGESTION_URL=http://localhost:4318/events \
-#   bash tests/validate-real-github-mcp.sh
-#
-# Output:
-#   Validation log to stdout
-#   MCP and emitter traces to stderr
-#   Summary at end: PASS / FAIL per check
+#   GITHUB_PERSONAL_ACCESS_TOKEN=<pat> bash tests/validate-real-github-mcp.sh
 
 set -euo pipefail
 
@@ -31,150 +31,266 @@ cd "$REPO_ROOT"
 
 PASS=0
 FAIL=0
+WARN=0
 RESULTS=()
 
-pass() { PASS=$((PASS+1)); RESULTS+=("[PASS] $1"); echo "  [PASS] $1"; }
-fail() { FAIL=$((FAIL+1)); RESULTS+=("[FAIL] $1"); echo "  [FAIL] $1"; }
-section() { echo; echo "── $1 ──"; }
+pass() { PASS=$((PASS+1)); RESULTS+=("[PASS] [$1] $2"); echo "  [PASS] $2"; }
+fail() { FAIL=$((FAIL+1)); RESULTS+=("[FAIL] [$1] $2"); echo "  [FAIL] $2"; }
+warn() { WARN=$((WARN+1)); RESULTS+=("[WARN] [$1] $2"); echo "  [WARN] $2"; }
+section() { echo; echo "── Layer $1: $2 ──"; }
 
-# ── 0. Pre-flight ─────────────────────────────────────────────────────────────
+STDERR_LOG="${REPO_ROOT}/validate-mcp.stderr.log"
+: > "$STDERR_LOG"  # truncate on each run
 
-section "0. Pre-flight"
+# ── Pre-flight ────────────────────────────────────────────────────────────────
+
+echo
+echo "══════════════════════════════════════════"
+echo "GitHub MCP Transport Validation"
+echo "══════════════════════════════════════════"
+echo "Repo:       $REPO_ROOT"
+echo "Date:       $(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+echo "Ingestion:  ${EVENT_INGESTION_URL:-'not configured (JSONL fallback)'}"
 
 if [ -z "${GITHUB_PERSONAL_ACCESS_TOKEN:-}" ]; then
+  echo
   echo "ERROR: GITHUB_PERSONAL_ACCESS_TOKEN is not set."
   echo "Usage: GITHUB_PERSONAL_ACCESS_TOKEN=<pat> bash tests/validate-real-github-mcp.sh"
   exit 1
 fi
-echo "  GITHUB_PERSONAL_ACCESS_TOKEN: set (not logged)"
+echo "PAT:        set (not logged)"
+
+# ── Layer 1: Container / runtime ──────────────────────────────────────────────
+
+section "1" "Container / runtime"
 
 if ! command -v docker &>/dev/null; then
-  echo "ERROR: Docker not found. Install Docker and retry."
+  fail "L1" "Docker not found — install Docker and retry"
+  echo; echo "Cannot continue: Docker is required."; exit 1
+fi
+if ! docker info &>/dev/null 2>&1; then
+  fail "L1" "Docker daemon is not running"
   exit 1
 fi
-if ! docker info &>/dev/null; then
-  echo "ERROR: Docker daemon is not running."
-  exit 1
-fi
-echo "  Docker: running"
+pass "L1" "Docker running"
 
-if [ ! -f "package.json" ] || [ ! -d "node_modules/@modelcontextprotocol/sdk" ]; then
+if [ ! -d "node_modules/@modelcontextprotocol/sdk" ]; then
   echo "  Running npm install..."
-  npm install
+  npm install 2>>"$STDERR_LOG"
 fi
-echo "  Dependencies: ok"
+pass "L1" "Node dependencies installed"
 
-# ── 1. Docker image pull ──────────────────────────────────────────────────────
-
-section "1. Pull GitHub MCP server image"
-
-if docker pull ghcr.io/github/github-mcp-server 2>&1 | tail -3; then
-  pass "Docker image pulled: ghcr.io/github/github-mcp-server"
+echo "  Pulling ghcr.io/github/github-mcp-server..."
+if docker pull ghcr.io/github/github-mcp-server >>"$STDERR_LOG" 2>&1; then
+  pass "L1" "Docker image pulled: ghcr.io/github/github-mcp-server"
 else
-  fail "Docker image pull failed"
-  echo "Cannot continue without the image." && exit 1
+  fail "L1" "Docker image pull failed — check $STDERR_LOG"
+  exit 1
 fi
 
-# ── 2. Transport unit tests (no network) ─────────────────────────────────────
-
-section "2. Unit validation (demo transport)"
-
-if node tests/validate-mcp-transport.js 2>/dev/null | tail -3; then
-  pass "validate-mcp-transport.js: all tests passed"
+# Unit test gate: demo transport must be clean before proceeding
+echo
+echo "  Running unit validation (demo transport)..."
+if node tests/validate-mcp-transport.js 2>/dev/null | grep -q "Results:.*0 failed"; then
+  pass "L1" "Unit validation: all tests passed"
 else
-  fail "validate-mcp-transport.js: one or more tests failed"
+  fail "L1" "Unit validation: one or more tests failed — run: node tests/validate-mcp-transport.js"
 fi
 
-# ── 3. Tool discovery ─────────────────────────────────────────────────────────
+# ── Layer 2: MCP session ──────────────────────────────────────────────────────
 
-section "3. Tool discovery (real GitHub MCP server)"
+section "2" "MCP session"
 
+# Step 2a: Tool discovery
 TOOLS_JSON=$(mktemp /tmp/mcp-tools-XXXXXXXX.json)
+TOOL_COUNT=0
 
-if node src/mcp-client/discover-tools.js --json 2>>"$REPO_ROOT/validate-mcp.stderr.log" > "$TOOLS_JSON"; then
+if node src/mcp-client/discover-tools.js --json 2>>"$STDERR_LOG" > "$TOOLS_JSON"; then
   TOOL_COUNT=$(python3 -c "import json; print(len(json.load(open('$TOOLS_JSON'))))" 2>/dev/null || echo 0)
-  pass "Tool discovery: ${TOOL_COUNT} tools returned"
-  echo
-  echo "  Tool list:"
-  python3 -c "
+  pass "L2" "MCP client connected and tools listed: ${TOOL_COUNT} tools"
+else
+  fail "L2" "Tool discovery failed — MCP connection or server error (see $STDERR_LOG)"
+  rm -f "$TOOLS_JSON"
+  echo; echo "Cannot continue: MCP session layer failed."; exit 1
+fi
+
+# Print tool list
+echo
+echo "  Tool list:"
+python3 -c "
 import json
 tools = json.load(open('$TOOLS_JSON'))
 for t in sorted(tools, key=lambda x: x['name']):
     req = ', '.join(t.get('inputSchema',{}).get('required',[]) or [])
-    print(f'    {t[\"name\"]:40s}  required: [{req}]')
+    print(f'    {t[\"name\"]:45s}  required: [{req}]')
 "
-  echo
+echo
 
-  # Extract key tool names for use in subsequent steps
-  GET_ME=$(python3 -c "
-import json; tools=json.load(open('$TOOLS_JSON'))
-candidates = [t['name'] for t in tools if 'me' in t['name'].lower() or 'user' in t['name'].lower() and 'authenticated' in t.get('description','').lower()]
-print(candidates[0] if candidates else 'get_me')
-" 2>/dev/null || echo "get_me")
-  SEARCH=$(python3 -c "
-import json; tools=json.load(open('$TOOLS_JSON'))
-candidates = [t['name'] for t in tools if 'search' in t['name'].lower() and 'repo' in t['name'].lower()]
-print(candidates[0] if candidates else 'search_repositories')
-" 2>/dev/null || echo "search_repositories")
-  echo "  Resolved tool names: me=${GET_ME}  search=${SEARCH}"
+# Step 2b: Safe probe tool resolution
+PROBE_TOOLS_JSON=$(mktemp /tmp/mcp-probe-XXXXXXXX.json)
+if node src/mcp-client/resolve-probe-tools.js 2>>"$STDERR_LOG" > "$PROBE_TOOLS_JSON"; then
+  IDENTITY_TOOL=$(python3 -c "import json; print(json.load(open('$PROBE_TOOLS_JSON'))['identity'])")
+  SEARCH_TOOL=$(python3 -c "import json; v=json.load(open('$PROBE_TOOLS_JSON'))['search']; print(v if v else 'none')")
+  pass "L2" "Safe probe tools resolved: identity=${IDENTITY_TOOL}  search=${SEARCH_TOOL}"
 else
-  fail "Tool discovery failed — check validate-mcp.stderr.log"
-  GET_ME="get_me"
-  SEARCH="search_repositories"
+  fail "L2" "Probe tool resolution failed — no safe identity probe available"
+  rm -f "$TOOLS_JSON" "$PROBE_TOOLS_JSON"
+  exit 1
 fi
 
-# ── 4. Connection probe ───────────────────────────────────────────────────────
+# Step 2c: Identity probe call (--probe uses tool-selector internally)
+PROBE_EXIT=0
+node src/mcp-client/discover-tools.js --probe 2>>"$STDERR_LOG" >/dev/null || PROBE_EXIT=$?
 
-section "4. Connection probe (real GitHub MCP server)"
-
-if node src/mcp-client/discover-tools.js --probe 2>>"$REPO_ROOT/validate-mcp.stderr.log" | head -20; then
-  pass "Connection probe: successful"
+if [ "$PROBE_EXIT" -eq 0 ]; then
+  pass "L2" "Identity probe call succeeded (${IDENTITY_TOOL})"
+elif [ "$PROBE_EXIT" -eq 2 ]; then
+  # Exit 2 = GitHub API auth failure, NOT MCP failure
+  pass "L2" "Identity probe MCP call completed (${IDENTITY_TOOL}) — GitHub API auth result: see Layer 3"
 else
-  fail "Connection probe: failed — check validate-mcp.stderr.log"
+  fail "L2" "Identity probe call failed at MCP transport level (exit ${PROBE_EXIT}) — see $STDERR_LOG"
 fi
 
-# ── 5. Instrumented session ───────────────────────────────────────────────────
+# ── Layer 3: GitHub API auth ──────────────────────────────────────────────────
 
-section "5. Instrumented session (real transport, JSONL fallback)"
+section "3" "GitHub API auth"
 
-SESSION_LOG=$(mktemp /tmp/mcp-session-XXXXXXXX.log)
+# Determine auth outcome from the probe result in STDERR_LOG
+if grep -q "Probe success" "$STDERR_LOG" 2>/dev/null; then
+  pass "L3" "GitHub API auth: credentials accepted by ${IDENTITY_TOOL}"
+elif grep -q "GitHub API auth failure" "$STDERR_LOG" 2>/dev/null; then
+  fail "L3" "GitHub API auth: 401/403 returned — PAT invalid, expired, or missing required scope"
+  echo "  Note: MCP session and tool invocation succeeded; this is a credential issue."
+  echo "  Required scope for get_me: 'read:user' or 'user'"
+elif grep -q "Probe classification: mcp_error" "$STDERR_LOG" 2>/dev/null; then
+  fail "L3" "GitHub API call failed at MCP level — see $STDERR_LOG for transport error"
+else
+  warn "L3" "GitHub API auth result unknown — probe may not have run"
+fi
 
-# Run the instrumented demo session with real transport
-# Events go to JSONL fallback if EVENT_INGESTION_URL is not set
+# ── Layer 4: Audit event pipeline ────────────────────────────────────────────
+
+section "4" "Audit event pipeline"
+
+# Determine evidence path: ingestion server OR JSONL fallback (not both required).
+USE_INGESTION=false
+if [ -n "${EVENT_INGESTION_URL:-}" ]; then
+  HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" "${EVENT_INGESTION_URL%/events}/events?limit=1" 2>/dev/null || echo "000")
+  if [ "$HTTP_STATUS" = "200" ]; then
+    USE_INGESTION=true
+    pass "L4" "Ingestion server reachable at ${EVENT_INGESTION_URL}"
+  else
+    warn "L4" "EVENT_INGESTION_URL is set but server returned HTTP ${HTTP_STATUS} — using JSONL fallback"
+    USE_INGESTION=false
+  fi
+else
+  echo "  EVENT_INGESTION_URL not configured — using JSONL fallback"
+  echo "  To enable ingestion path: start server, then set EVENT_INGESTION_URL=http://localhost:4318/events"
+fi
+
+# Capture baseline for JSONL (always, so we have it for trace verification)
 JSONL_BEFORE=0
 if [ -f "audit-log/tool-invocations.jsonl" ]; then
   JSONL_BEFORE=$(wc -l < "audit-log/tool-invocations.jsonl")
 fi
 
-if TOOL_NAME_ME="$GET_ME" TOOL_NAME_SEARCH="$SEARCH" \
-   node src/mcp-client/demo-github-session.js \
-   > "$SESSION_LOG" 2>>"$REPO_ROOT/validate-mcp.stderr.log"; then
-  pass "Instrumented session: completed without error"
+# Run instrumented session
+SESSION_LOG=$(mktemp /tmp/mcp-session-XXXXXXXX.log)
+SESSION_OK=false
+
+SESSION_ENV="TOOL_NAME_ME=${IDENTITY_TOOL}"
+if [ "$SEARCH_TOOL" != "none" ]; then
+  SESSION_ENV="${SESSION_ENV} TOOL_NAME_SEARCH=${SEARCH_TOOL}"
+fi
+
+if eval "${SESSION_ENV}" node src/mcp-client/demo-github-session.js \
+    > "$SESSION_LOG" 2>>"$STDERR_LOG"; then
+  SESSION_OK=true
+  pass "L4" "Instrumented session completed without error"
 else
-  fail "Instrumented session: exited with error"
+  fail "L4" "Instrumented session exited with error — see $STDERR_LOG"
 fi
 
 cat "$SESSION_LOG"
 
-# Count new events appended to JSONL
-if [ -f "audit-log/tool-invocations.jsonl" ]; then
-  JSONL_AFTER=$(wc -l < "audit-log/tool-invocations.jsonl")
-  NEW_EVENTS=$((JSONL_AFTER - JSONL_BEFORE))
-  if [ "$NEW_EVENTS" -ge 4 ]; then
-    pass "Audit events: ${NEW_EVENTS} new events emitted (expected ≥4)"
+# Audit evidence — check the active path only
+NEW_EVENTS=0
+
+if $USE_INGESTION; then
+  # Primary evidence: ingestion server
+  sleep 1  # allow async HTTP delivery
+  INGESTION_COUNT=$(curl -s "${EVENT_INGESTION_URL%/events}/events?limit=100" | \
+    python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('count',0))" 2>/dev/null || echo 0)
+  if [ "$INGESTION_COUNT" -gt 0 ]; then
+    pass "L4" "Events readable from ingestion server: total stored=${INGESTION_COUNT}"
   else
-    fail "Audit events: only ${NEW_EVENTS} new events (expected ≥4: session.start + 2×tool.invocation + session.end)"
+    fail "L4" "No events readable from ingestion server"
   fi
+
+  # Count new JSONL lines for session trace verification only (not as primary evidence)
+  if [ -f "audit-log/tool-invocations.jsonl" ]; then
+    JSONL_AFTER=$(wc -l < "audit-log/tool-invocations.jsonl")
+    NEW_EVENTS=$((JSONL_AFTER - JSONL_BEFORE))
+  fi
+  # JSONL growth is not required when ingestion is active
 else
-  fail "Audit events: audit-log/tool-invocations.jsonl not found"
+  # Fallback evidence: JSONL
+  if [ -f "audit-log/tool-invocations.jsonl" ]; then
+    JSONL_AFTER=$(wc -l < "audit-log/tool-invocations.jsonl")
+    NEW_EVENTS=$((JSONL_AFTER - JSONL_BEFORE))
+    if [ "$NEW_EVENTS" -ge 4 ]; then
+      pass "L4" "JSONL fallback: ${NEW_EVENTS} new events written"
+    else
+      fail "L4" "JSONL fallback: only ${NEW_EVENTS} new events (expected ≥4)"
+    fi
+  else
+    fail "L4" "JSONL fallback: audit-log/tool-invocations.jsonl not found"
+  fi
 fi
 
-# ── 6. Session trace verification ────────────────────────────────────────────
+# Session trace verification (correlation_id consistency)
+# Use JSONL for trace even in ingestion mode — events are always written to JSONL fallback
+# unless EVENT_INGESTION_URL is set. In ingestion mode check ingestion server instead.
+echo
+echo "  Session trace:"
 
-section "6. Session trace verification"
+if $USE_INGESTION; then
+  TRACE=$(curl -s "${EVENT_INGESTION_URL%/events}/events?limit=10" 2>/dev/null | \
+    python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+events = d.get('events', [])
+# find the most recent correlation_id group
+ids = {}
+for e in events:
+    c = e.get('correlation_id','')
+    ids.setdefault(c, []).append(e)
+if not ids:
+    print('no_events')
+else:
+    # Most recent group is the one from this run
+    corr = list(ids.keys())[-1]
+    group = ids[corr]
+    print(f'correlation_id={corr}')
+    for e in group:
+        print(f'  [{e[\"event_type\"]:20s}] action={e[\"action\"]:30s} status={e[\"status\"]}')
+    types = {e['event_type'] for e in group}
+    has_start = 'session.start' in types
+    has_end = 'session.end' in types
+    has_tool = 'tool.invocation' in types
+    print(f'session.start={has_start} tool.invocation={has_tool} session.end={has_end}')
+" 2>/dev/null || echo "trace_check_failed")
 
-if [ -f "audit-log/tool-invocations.jsonl" ] && [ "$NEW_EVENTS" -ge 1 ] 2>/dev/null; then
-  # Extract correlation_id from the latest session.start event
+  if echo "$TRACE" | grep -q "session.start=True"; then
+    CORR_ID=$(echo "$TRACE" | grep "correlation_id=" | head -1 | cut -d= -f2)
+    pass "L4" "Session trace complete: session.start + tool.invocation + session.end (corr=${CORR_ID})"
+  else
+    warn "L4" "Session trace incomplete from ingestion server"
+  fi
+  echo
+  echo "$TRACE" | sed 's/^/    /'
+
+elif [ -f "audit-log/tool-invocations.jsonl" ] && [ "${NEW_EVENTS:-0}" -ge 1 ]; then
   CORR_ID=$(tail -"${NEW_EVENTS}" audit-log/tool-invocations.jsonl | \
     python3 -c "
 import sys, json
@@ -186,47 +302,27 @@ for line in sys.stdin:
 " 2>/dev/null || echo "")
 
   if [ -n "$CORR_ID" ]; then
-    pass "session.start event found: correlation_id=${CORR_ID}"
-
-    # Count events with this correlation_id
-    TRACE_COUNT=$(tail -"${NEW_EVENTS}" audit-log/tool-invocations.jsonl | \
-      python3 -c "
-import sys, json
-n=0
-for line in sys.stdin:
-    e=json.loads(line.strip())
-    if e.get('correlation_id') == '${CORR_ID}':
-        n+=1
-print(n)
-" 2>/dev/null || echo 0)
-
     HAS_END=$(tail -"${NEW_EVENTS}" audit-log/tool-invocations.jsonl | \
       python3 -c "
 import sys, json
 for line in sys.stdin:
     e=json.loads(line.strip())
-    if e.get('event_type') == 'session.end' and e.get('correlation_id') == '${CORR_ID}':
-        print('yes')
-        break
+    if e.get('event_type')=='session.end' and e.get('correlation_id')=='${CORR_ID}': print('yes'); break
 " 2>/dev/null || echo "no")
-
     HAS_TOOL=$(tail -"${NEW_EVENTS}" audit-log/tool-invocations.jsonl | \
       python3 -c "
 import sys, json
 for line in sys.stdin:
     e=json.loads(line.strip())
-    if e.get('event_type') == 'tool.invocation' and e.get('correlation_id') == '${CORR_ID}':
-        print('yes')
-        break
+    if e.get('event_type')=='tool.invocation' and e.get('correlation_id')=='${CORR_ID}': print('yes'); break
 " 2>/dev/null || echo "no")
 
-    [ "$HAS_END" = "yes" ] && pass "session.end event found for correlation_id" || fail "session.end event missing"
-    [ "$HAS_TOOL" = "yes" ] && pass "tool.invocation event found for correlation_id" || fail "tool.invocation event missing"
-    echo "  Trace: ${TRACE_COUNT} events under correlation_id=${CORR_ID}"
+    if [ "$HAS_END" = "yes" ] && [ "$HAS_TOOL" = "yes" ]; then
+      pass "L4" "Session trace complete: session.start + tool.invocation + session.end (corr=${CORR_ID})"
+    else
+      fail "L4" "Session trace incomplete (has_end=${HAS_END} has_tool=${HAS_TOOL})"
+    fi
 
-    # Print the trace
-    echo
-    echo "  Event trace:"
     tail -"${NEW_EVENTS}" audit-log/tool-invocations.jsonl | \
       python3 -c "
 import sys, json
@@ -236,48 +332,14 @@ for line in sys.stdin:
         print(f'    [{e[\"event_type\"]:20s}] action={e[\"action\"]:30s} status={e[\"status\"]}')
 "
   else
-    fail "Could not extract correlation_id from session.start event"
-  fi
-fi
-
-# ── 7. Ingestion server pipeline (optional) ───────────────────────────────────
-
-section "7. Ingestion server pipeline"
-
-if [ -n "${EVENT_INGESTION_URL:-}" ]; then
-  echo "  EVENT_INGESTION_URL=${EVENT_INGESTION_URL}"
-  HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" "${EVENT_INGESTION_URL%/events}/events?limit=1" 2>/dev/null || echo "000")
-  if [ "$HTTP_STATUS" = "200" ]; then
-    pass "Ingestion server reachable at ${EVENT_INGESTION_URL}"
-    # Re-run session with ingestion server active
-    if TOOL_NAME_ME="$GET_ME" TOOL_NAME_SEARCH="$SEARCH" \
-       EVENT_INGESTION_URL="$EVENT_INGESTION_URL" \
-       node src/mcp-client/demo-github-session.js \
-       2>>"$REPO_ROOT/validate-mcp.stderr.log" >/dev/null; then
-      pass "Instrumented session with ingestion pipeline: completed"
-      # Wait briefly for async delivery
-      sleep 1
-      COUNT=$(curl -s "${EVENT_INGESTION_URL%/events}/events?limit=10" | \
-        python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('count',0))" 2>/dev/null || echo 0)
-      pass "Events readable from ingestion server: count=${COUNT}"
-    else
-      fail "Instrumented session with ingestion pipeline: failed"
-    fi
-  else
-    echo "  Ingestion server not reachable (HTTP ${HTTP_STATUS}) — skipping pipeline check"
-    echo "  To include this check: start the ingestion server first:"
-    echo "    PORT=4318 node src/ingestion/server.js &"
+    warn "L4" "Could not extract session trace from JSONL"
   fi
 else
-  echo "  EVENT_INGESTION_URL not set — skipping ingestion pipeline check"
-  echo "  To include: EVENT_INGESTION_URL=http://localhost:4318/events bash $0"
+  warn "L4" "Skipping JSONL trace (no new events in fallback path)"
 fi
 
-# ── 8. Schema conformity spot-check ──────────────────────────────────────────
-
-section "8. Schema conformity spot-check"
-
-if [ -f "audit-log/tool-invocations.jsonl" ] && [ "${NEW_EVENTS:-0}" -ge 1 ]; then
+# Schema conformity spot-check
+if ! $USE_INGESTION && [ "${NEW_EVENTS:-0}" -ge 1 ] && [ -f "audit-log/tool-invocations.jsonl" ]; then
   INVALID=$(tail -"${NEW_EVENTS}" audit-log/tool-invocations.jsonl | \
     python3 -c "
 import sys, json
@@ -300,14 +362,16 @@ print(f'invalid_count={invalid}')
 " 2>/dev/null || echo "invalid_count=check_failed")
 
   if echo "$INVALID" | grep -q "invalid_count=0"; then
-    pass "Schema conformity: all ${NEW_EVENTS} new events have required fields"
+    pass "L4" "Schema conformity: all ${NEW_EVENTS} new events have required fields"
   else
-    fail "Schema conformity: one or more events missing required fields"
+    fail "L4" "Schema conformity: one or more events missing required fields"
     echo "$INVALID"
   fi
 fi
 
 # ── Summary ───────────────────────────────────────────────────────────────────
+
+rm -f "$TOOLS_JSON" "$PROBE_TOOLS_JSON" "$SESSION_LOG" 2>/dev/null
 
 echo
 echo "══════════════════════════════════════════"
@@ -315,13 +379,14 @@ echo "Validation Summary"
 echo "══════════════════════════════════════════"
 for r in "${RESULTS[@]}"; do echo "  $r"; done
 echo
-echo "  Passed: ${PASS}  Failed: ${FAIL}"
+echo "  Passed: ${PASS}  Warned: ${WARN}  Failed: ${FAIL}"
 echo
 
-# Cleanup
-rm -f "$TOOLS_JSON" "$SESSION_LOG" 2>/dev/null
-
 if [ "$FAIL" -gt 0 ]; then
-  echo "  Full stderr log: ${REPO_ROOT}/validate-mcp.stderr.log"
+  echo "  Full stderr log: ${STDERR_LOG}"
   exit 1
+fi
+
+if [ "$WARN" -gt 0 ]; then
+  echo "  Full stderr log: ${STDERR_LOG}"
 fi


### PR DESCRIPTION
## Summary

Implements CC-HMCP-000005C by correcting the live GitHub MCP validation flow so that it selects safe probe tools, reports failures by layer, and only expects JSONL fallback output when fallback mode is actually active.

This addresses the issues found during live validation:
- incorrect representative tool selection
- auth failures being reported as transport/session failures
- JSONL fallback checks running even when ingestion-backed evidence was configured

## What changed

- Added explicit tool-selection logic for validation probes
- Added mutation denylist and safe preference ordering for identity/search probes
- Added result classification for distinguishing MCP/session failures from GitHub auth failures
- Updated discovery flow to use the safe selector and return layer-specific exit codes
- Added a probe-resolution helper for shell-script consumption
- Reworked the live validation script to report by layer and to check only the active evidence path
- Expanded automated validation coverage for tool selection and result classification

## Files

- `src/mcp-client/tool-selector.js`
- `src/mcp-client/discover-tools.js`
- `src/mcp-client/resolve-probe-tools.js`
- `tests/validate-real-github-mcp.sh`
- `tests/validate-mcp-transport.js`
- `package.json`

## Why this change

Live validation had already shown that:
- MCP session establishment was working
- tool discovery was working
- ingestion was working

But the evidence path was distorted by three issues:
1. the identity probe could select an unsafe or irrelevant tool
2. GitHub API auth failures were being collapsed into generic connection failure
3. JSONL fallback was being treated as required even in ingestion mode

This PR fixes those issues so operators can tell which layer succeeded and which layer failed.

## Architectural notes

This remains a validation-focused change and does not alter the emitter or transport contracts.

Important decisions:
- `get_me` is now explicitly preferred for identity probing when available
- mutation-capable tools are blocked from representative probe selection
- exit codes distinguish full success, auth failure, and MCP/transport failure
- ingestion-backed evidence is treated as primary when `EVENT_INGESTION_URL` is configured

## Validation

Validation passed:

- 27 tests passed
- 0 failed

New coverage includes:
- tool selector behavior
- write-tool rejection for identity probing
- auth failure classification
- conditional JSONL expectations in ingestion mode

## Follow-on notes

- A PAT used for live validation may still fail the identity probe if it lacks the necessary user scope
- Fine-grained tokens limited to repository access may still produce Layer 3 auth failure for `get_me`
- Probe resolution now performs a real server connection, which may add startup time during validation runs

## Outcome

This PR improves the accuracy and trustworthiness of live GitHub MCP validation without expanding platform scope.