### PR TITLE
Implements CTRL-HMCP-000002 — Deny Destructive Tools by Default

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -406,3 +406,8 @@ If a prompt is resumed after an interruption:
 - PR text generation is a separate step, typically done after the execution summary is reviewed
 
 ---
+
+## Auto-Approve Convention
+
+- Execution prompts may optionally include an Auto-Approve header. 
+- ChatGPT should ask the user whether to enable it before generating implementation prompts unless the user already made that explicit for the current task.

--- a/chatgpt-primer.md
+++ b/chatgpt-primer.md
@@ -447,3 +447,12 @@ If a generated prompt breaks markdown rendering or splits unexpectedly:
 No malformed prompt should be accepted into workflow.
 
 ---
+
+## Auto-Approve Prompt Rule
+
+When ChatGPT prepares a Claude Code execution prompt for implementation work, ChatGPT must explicitly ask whether to include the Auto-Approve header before generating the final prompt.
+
+Default behavior:
+- Do not assume Auto-Approve is enabled
+- Ask once per new execution task unless the user already explicitly requested it
+- Handoff prompts and non-implementation prompts do not require Auto-Approve unless specifically requested

--- a/docs/controls/deny-destructive-tools-by-default.md
+++ b/docs/controls/deny-destructive-tools-by-default.md
@@ -1,0 +1,184 @@
+# Deny Destructive Tools by Default — CTRL-HMCP-000002
+
+**Status:** Active  
+**Implemented by:** CC-HMCP-000010  
+**Depends on:** CTRL-HMCP-000001 (Tool Risk Classification)
+
+---
+
+## Purpose
+
+Implements the first enforcement control in the MCP control layer. Tools classified as `DESTRUCTIVE` with `allowed_by_default=false` are blocked by default before execution proceeds. The denial is recorded as an audit event.
+
+---
+
+## How Deny-by-Default Works
+
+At the point of tool invocation, the caller invokes `checkAndEnforcePolicy(context)` before passing the tool call to the underlying MCP transport.
+
+The policy gate:
+
+1. Looks up the tool in `config/tool-classifications.json`
+2. Checks whether `risk_level === 'DESTRUCTIVE'` and `allowed_by_default === false`
+3. If both conditions are met and no override is active, the decision is `denied`
+4. A `tool.denial` audit event is emitted with the tool name, risk level, and denial reason
+5. The decision object is returned to the caller — the caller must not execute the tool if `allowed === false`
+
+If the tool is not in the registry, it is allowed (unclassified tools are not subject to this enforcement gate).
+
+---
+
+## What Qualifies as DESTRUCTIVE
+
+A tool is classified `DESTRUCTIVE` when it:
+
+- Performs irreversible operations (deletions, truncations, force operations)
+- Can cause data loss that has no automatic undo path
+- Could cause significant service disruption
+
+Current `DESTRUCTIVE` tools in the registry:
+
+| Tool | Description |
+|---|---|
+| `delete_branch` | Deletes a branch; unmerged commits may be lost |
+
+See `config/tool-classifications.json` for the full registry. See `docs/controls/tool-risk-classification.md` for classification definitions and the process for adding new entries.
+
+---
+
+## Denial Result Structure
+
+`checkAndEnforcePolicy(context)` returns a decision object:
+
+```json
+{
+  "allowed": false,
+  "toolName": "delete_branch",
+  "riskLevel": "DESTRUCTIVE",
+  "reason": "policy_denied",
+  "policyBasis": "destructive_tool_not_allowed_by_default"
+}
+```
+
+| Field | Type | Values |
+|---|---|---|
+| `allowed` | boolean | `true` / `false` |
+| `toolName` | string | tool name as passed |
+| `riskLevel` | string\|null | `LOW` / `MEDIUM` / `HIGH` / `DESTRUCTIVE` / `null` |
+| `reason` | string | `allowed` / `policy_denied` / `override_allowed` |
+| `policyBasis` | string | machine-readable policy explanation |
+
+---
+
+## Audit Evidence
+
+When a tool is denied, a `tool.denial` event is emitted:
+
+```json
+{
+  "schema_version": "0.2.0",
+  "event_id": "...",
+  "event_type": "tool.denial",
+  "timestamp": "2026-04-07T14:00:00Z",
+  "platform": "home-mcp-lab",
+  "project_id": "home-mcp-lab",
+  "agent_id": "claude-code-session-dude-mcp-01",
+  "mcp_server": "github-mcp-server",
+  "action": "delete_branch",
+  "status": "failure",
+  "correlation_id": "sess-20260407-abc123",
+  "metadata": {
+    "tool_name": "delete_branch",
+    "risk_level": "DESTRUCTIVE",
+    "denial_reason": "policy_denied",
+    "policy_basis": "destructive_tool_not_allowed_by_default"
+  }
+}
+```
+
+The `tool.denial` event is defined in `schemas/audit-event.schema.json`.
+
+---
+
+## Override Mechanism
+
+Override is intentional by design. Two paths are available:
+
+### Option 1 — Per-call context flag
+
+Pass `allowDestructive: true` in the execution context:
+
+```javascript
+const decision = checkAndEnforcePolicy({
+  toolName: 'delete_branch',
+  projectId: 'home-mcp-lab',
+  agentId: 'claude-code-1',
+  mcpServer: 'github-mcp-server',
+  correlationId: sessionCtx.correlationId,
+  allowDestructive: true  // explicit override
+});
+```
+
+When override is active, `reason` is `override_allowed` and `policyBasis` is `destructive_tool_allowed_by_explicit_override`. The decision is logged at the caller's discretion.
+
+### Option 2 — Environment variable
+
+Set `HMCP_ALLOW_DESTRUCTIVE=true` in the process environment.
+
+This is intended for lab use only. It unlocks all `DESTRUCTIVE` tools for the lifetime of the process. It must not be set in production or CI environments.
+
+**Both override paths are intentional acts. Neither is ever active by default.**
+
+To restore deny-by-default:
+- Remove `allowDestructive: true` from the context, or
+- Unset the environment variable
+
+---
+
+## Integration Pattern
+
+```javascript
+const { checkAndEnforcePolicy, withToolInstrumentation } = require('./src/emitter');
+
+// In the session invocation path:
+const decision = checkAndEnforcePolicy({
+  toolName,
+  projectId,
+  agentId,
+  mcpServer,
+  correlationId
+});
+
+if (!decision.allowed) {
+  // Tool is denied. Do not invoke. The denial event is already emitted.
+  return { denied: true, reason: decision.reason, policyBasis: decision.policyBasis };
+}
+
+// Allowed — proceed with instrumented invocation.
+return withToolInstrumentation({ toolName, projectId, agentId, mcpServer, correlationId }, fn);
+```
+
+---
+
+## Relationship to Other Controls
+
+| Control | Status | Dependency |
+|---|---|---|
+| CTRL-HMCP-000001 — Tool Risk Classification | Active | Required — provides the risk level and `allowed_by_default` data this gate reads |
+| CTRL-HMCP-000002 — Deny Destructive by Default | **Active (this doc)** | — |
+| CTRL-HMCP-000003 — Approval-Required Execution (planned) | Planned | Will extend the policy gate to add an approval flow for HIGH tools before execution |
+
+CTRL-HMCP-000003 will build on this gate. The `evaluatePolicy` function in `src/policy/policy-gate.js` is designed to be extended with additional enforcement tiers without breaking the existing denial path.
+
+---
+
+## Non-Goals
+
+This control does not:
+
+- Block HIGH, MEDIUM, or LOW tools
+- Implement approval workflows
+- Apply any logic based on argument content
+- Enforce per-project or per-agent policies
+
+Those are out of scope and reserved for future controls.

--- a/docs/handoffs/handoff-CC-HMCP-000010.md
+++ b/docs/handoffs/handoff-CC-HMCP-000010.md
@@ -1,0 +1,142 @@
+# Handoff — 2026-04-07 / CC-HMCP-000010
+
+## Current System State
+
+- **Last Completed Task:** CC-HMCP-000010 — Deny Destructive Tools by Default (CTRL-HMCP-000002)
+- **Current Phase:** Control Layer — early enforcement
+- **Active Branch:** `feature/cc-hmcp-000010-deny-destructive-tools-by-default`
+- **PR Status:** PR #65 open — pending merge
+- **Main Branch:** clean through PR #64 (CC-HMCP-000009 — Tool Risk Classification)
+
+---
+
+## Completed Work (This Session)
+
+### CC-HMCP-000009 — Tool Risk Classification (PR #64, merged)
+
+- `schemas/tool-classification.schema.json` — schema for registry entries; defines `tool_name`, `risk_level` (enum), `description`, `rationale`, `allowed_by_default`
+- `config/tool-classifications.json` — registry seeded with 12 GitHub MCP tool classifications across LOW / MEDIUM / HIGH / DESTRUCTIVE
+- `src/emitter/classification-registry.js` — registry loader; `lookupRiskLevel(toolName)` returns risk level or null
+- `src/emitter/event-builder.js` — `buildToolInvocationEvent` attaches `risk_level` to metadata when present in context
+- `src/emitter/index.js` — `emitToolInvocation` auto-resolves `risk_level` from registry before event construction
+- `schemas/audit-event.schema.json` — `risk_level` documented in `tool.invocation` metadata fields
+- `docs/controls/tool-risk-classification.md` — full model definition, seeded classifications table, usage guide
+
+### CC-HMCP-000010 — Deny Destructive Tools by Default (PR #65, open)
+
+- `src/policy/policy-gate.js` — pure policy decision module; `evaluatePolicy(toolName, executionContext)` reads the full registry (including `allowed_by_default`), applies enforcement rule, checks override state, returns a structured decision with no side effects
+- `src/emitter/index.js` — adds `checkAndEnforcePolicy(context)`; the single enforcement call site; emits `tool.denial` when denied; returns decision to caller
+- `src/emitter/event-builder.js` — adds `buildToolDenialEvent`; builds `tool.denial` events conforming to schema shape
+- `schemas/audit-event.schema.json` — `tool.denial` added to `event_type` enum and definitions block
+- `docs/controls/deny-destructive-tools-by-default.md` — full control documentation: deny behavior, override paths, denial result shape, audit evidence example, integration pattern, relationship to CTRL-HMCP-000001/000003
+- `tests/validate-policy-gate.js` — 21 tests; all pass
+
+---
+
+## Current Behavior
+
+### Policy Evaluation
+
+When a caller invokes `checkAndEnforcePolicy(context)`, the system:
+
+1. Loads `config/tool-classifications.json` (cached after first load)
+2. Looks up the tool by name to retrieve its `risk_level` and `allowed_by_default` flag
+3. Applies the enforcement rule: a tool is subject to denial only when `risk_level === 'DESTRUCTIVE'` AND `allowed_by_default === false`
+4. Checks for an active override (see below)
+5. Returns a structured decision object to the caller
+
+The caller is responsible for gating execution on `decision.allowed`. The policy gate does not throw or invoke the tool itself.
+
+### When Destructive Tools Are Denied
+
+A tool is denied when:
+- It is registered in `config/tool-classifications.json` with `risk_level: "DESTRUCTIVE"` and `allowed_by_default: false`
+- No override is active
+
+Currently the only `DESTRUCTIVE` tool in the registry is `delete_branch`.
+
+HIGH tools with `allowed_by_default: false` (e.g., `merge_pull_request`) are **not** subject to this enforcement gate — only `DESTRUCTIVE` tools trigger it. This is intentional; HIGH enforcement is reserved for CTRL-HMCP-000003.
+
+### Decision Result Shape
+
+```json
+{
+  "allowed": false,
+  "toolName": "delete_branch",
+  "riskLevel": "DESTRUCTIVE",
+  "reason": "policy_denied",
+  "policyBasis": "destructive_tool_not_allowed_by_default"
+}
+```
+
+`reason` values: `allowed` | `policy_denied` | `override_allowed`
+
+### Override Mechanism
+
+Two paths, both intentional — neither is ever the default:
+
+1. **Per-call context flag:** pass `allowDestructive: true` in the context object passed to `checkAndEnforcePolicy`. Produces `reason: override_allowed`.
+2. **Environment variable:** set `HMCP_ALLOW_DESTRUCTIVE=true`. Applies for the lifetime of the process. Lab use only.
+
+Removing either restores deny-by-default with no code changes.
+
+### Audit Events Emitted
+
+When a tool is denied, `checkAndEnforcePolicy` emits a `tool.denial` event before returning:
+
+```json
+{
+  "event_type": "tool.denial",
+  "action": "delete_branch",
+  "status": "failure",
+  "metadata": {
+    "tool_name": "delete_branch",
+    "risk_level": "DESTRUCTIVE",
+    "denial_reason": "policy_denied",
+    "policy_basis": "destructive_tool_not_allowed_by_default"
+  }
+}
+```
+
+When a tool is allowed, no additional event is emitted by the policy gate. The normal `tool.invocation` event is emitted by the instrumentation layer as before.
+
+### Behavior for Unknown Tools
+
+Tools not in the registry are allowed. Unclassified tools are outside the enforcement scope. `riskLevel` is `null` and `policyBasis` is `unclassified_tool_allowed` in the returned decision.
+
+---
+
+## Known Issues / Gaps
+
+- **Missing `@modelcontextprotocol/sdk`:** 8 tests in `tests/validate-mcp-transport.js` fail because this npm dependency is not installed on the current machine. These failures are pre-existing and unrelated to the control layer work. All 21 policy gate tests pass.
+- **Enforcement is caller-invoked, not universal:** `checkAndEnforcePolicy` is a function callers must explicitly call. There is no automatic interception at a transport or MCP protocol layer. Callers who do not call it are not subject to enforcement. This is a known architectural limitation of the Model C (agent-mediated) instrumentation approach (ADR-HMCP-002).
+- **No approval workflow:** DESTRUCTIVE tools are denied outright with no approval path. This is intentional — approval-required execution is CTRL-HMCP-000003.
+- **VG-HMCP-000001:** Keeper service-context viability on dude-mcp-01 — open, no new evidence.
+- **VG-HMCP-000003:** GitHub PAT retrieval path visibility — implementation complete; awaiting live end-to-end validation on dude-mcp-01 with `EVENT_INGESTION_URL` set before full closure.
+
+---
+
+## Open Backlog (Relevant Subset)
+
+- **CTRL-HMCP-000003** — Approval-required tool execution for HIGH tools (natural next step after this task)
+- **TD-HMCP-000003** — Event completeness validation: verify that `tool.denial` and `tool.invocation` events are received and persisted correctly by the ingestion server under real conditions
+- **VG-HMCP-000003** — Live validation of `secret.retrieval` event emission on dude-mcp-01 (outstanding from Phase 2.5)
+
+---
+
+## Recommended Next Task
+
+**CTRL-HMCP-000003 — Approval-Required Tool Execution**
+
+The policy gate introduced in CC-HMCP-000010 is designed to be extended. The natural next step is to add a second enforcement tier for `HIGH` tools with `allowed_by_default: false` (e.g., `merge_pull_request`) that requires an explicit approval signal rather than an outright deny — building directly on `evaluatePolicy` in `src/policy/policy-gate.js` without breaking the existing DESTRUCTIVE denial path.
+
+---
+
+## Resume Instructions
+
+1. Merge PR #65 if not yet merged
+2. `git checkout main && git pull origin main`
+3. Verify the registry, policy-gate, and emitter are present on main (`config/tool-classifications.json`, `src/policy/policy-gate.js`, `src/emitter/index.js`)
+4. Create a new feature branch: `git checkout -b feature/cc-hmcp-000011-approval-required-execution` (or architect-assigned ID)
+5. Do not rely on the boot block (`CLAUDE.md`) for current state — it is stale. This handoff is authoritative.
+6. Paste `chatgpt-primer.md` + this handoff into ChatGPT to restore architect context before generating the next prompt

--- a/schemas/audit-event.schema.json
+++ b/schemas/audit-event.schema.json
@@ -38,7 +38,7 @@
     "event_type": {
       "type": "string",
       "description": "Categorizes the event. See defined event types below.",
-      "enum": ["tool.invocation", "secret.retrieval", "session.start", "session.end"],
+      "enum": ["tool.invocation", "tool.denial", "secret.retrieval", "session.start", "session.end"],
       "example": "tool.invocation"
     },
 
@@ -110,6 +110,17 @@
         "arguments_summary": "string — non-sensitive summary or schema of arguments; must not include secret or PII values",
         "execution_duration_ms": "number — duration of tool execution in milliseconds",
         "result_summary": "string — non-sensitive description of the outcome; must not include raw result data if sensitive"
+      }
+    },
+
+    "event_type.tool.denial": {
+      "description": "Emitted when a tool invocation is blocked by the platform policy gate before execution begins. The tool is never invoked. Emitted with status:'failure'.",
+      "metadata_fields": {
+        "tool_name": "string — name of the tool that was denied",
+        "risk_level": "string — risk classification at the time of denial: 'LOW' | 'MEDIUM' | 'HIGH' | 'DESTRUCTIVE' | 'UNKNOWN'",
+        "denial_reason": "string — machine-readable denial reason; currently 'policy_denied'",
+        "policy_basis": "string — machine-readable explanation of the policy that caused the denial (e.g. 'destructive_tool_not_allowed_by_default')",
+        "initiating_context": "string (optional) — prompt ID or workflow context if available"
       }
     },
 

--- a/src/emitter/event-builder.js
+++ b/src/emitter/event-builder.js
@@ -236,4 +236,50 @@ function buildSecretRetrievalEvent(context, outcome) {
   };
 }
 
-module.exports = { buildToolInvocationEvent, buildSessionStartEvent, buildSessionEndEvent, buildSecretRetrievalEvent };
+/**
+ * Builds a schema-conforming tool.denial audit event.
+ *
+ * Required context fields:
+ *   toolName, projectId, agentId, mcpServer, correlationId
+ *
+ * Required decision fields (from policy-gate evaluatePolicy result):
+ *   riskLevel, reason, policyBasis
+ *
+ * Throws if any required field is missing.
+ */
+function buildToolDenialEvent(context, decision) {
+  const required = ['toolName', 'projectId', 'agentId', 'mcpServer', 'correlationId'];
+  for (const field of required) {
+    if (!context[field]) {
+      throw new Error(`Missing required emitter context field: ${field}`);
+    }
+  }
+
+  const metadata = {
+    tool_name: context.toolName,
+    risk_level: decision.riskLevel || 'UNKNOWN',
+    denial_reason: decision.reason,
+    policy_basis: decision.policyBasis
+  };
+
+  if (context.initiatingContext) {
+    metadata.initiating_context = context.initiatingContext;
+  }
+
+  return {
+    schema_version: SCHEMA_VERSION,
+    event_id: randomUUID(),
+    event_type: 'tool.denial',
+    timestamp: new Date().toISOString(),
+    platform: PLATFORM,
+    project_id: context.projectId,
+    agent_id: context.agentId,
+    mcp_server: context.mcpServer,
+    action: context.toolName,
+    status: 'failure',
+    correlation_id: context.correlationId,
+    metadata
+  };
+}
+
+module.exports = { buildToolInvocationEvent, buildSessionStartEvent, buildSessionEndEvent, buildSecretRetrievalEvent, buildToolDenialEvent };

--- a/src/emitter/index.js
+++ b/src/emitter/index.js
@@ -12,6 +12,7 @@
  *   withToolInstrumentation(context, fn)   — wrap an async tool call with instrumentation
  *   emitSessionStart(context)              — emit session.start directly; returns correlationId
  *   emitSessionEnd(context, outcome)       — emit session.end directly
+ *   checkAndEnforcePolicy(context)         — evaluate policy; emit tool.denial if denied; returns decision
  *
  * Context shape:
  *   toolName           string  required  — MCP tool name (e.g. "create_issue")
@@ -26,10 +27,11 @@
  */
 
 const { randomUUID } = require('crypto');
-const { buildToolInvocationEvent, buildSessionStartEvent, buildSessionEndEvent, buildSecretRetrievalEvent } = require('./event-builder');
+const { buildToolInvocationEvent, buildSessionStartEvent, buildSessionEndEvent, buildSecretRetrievalEvent, buildToolDenialEvent } = require('./event-builder');
 const { submit } = require('./transport');
 const { record } = require('./failure-observer');
 const { lookupRiskLevel } = require('./classification-registry');
+const { evaluatePolicy } = require('../policy/policy-gate');
 
 function generateCorrelationId() {
   const date = new Date().toISOString().slice(0, 10).replace(/-/g, '');
@@ -260,4 +262,49 @@ function emitSecretRetrieval(context, outcome) {
   }
 }
 
-module.exports = { emitToolInvocation, withToolInstrumentation, emitSessionStart, emitSessionEnd, withSession, emitSecretRetrieval };
+/**
+ * Evaluate policy for a tool and emit a tool.denial event if denied.
+ *
+ * Returns a decision object. When allowed === false, the tool must not be
+ * invoked — the caller is responsible for gating execution on this result.
+ *
+ * Never throws — denial emission failures are handled by the failure observer.
+ *
+ * context shape — same as emitToolInvocation context plus:
+ *   allowDestructive  boolean  optional  — per-call explicit override; default false
+ *
+ * Returned decision shape:
+ *   {
+ *     allowed:      boolean
+ *     toolName:     string
+ *     riskLevel:    string|null
+ *     reason:       'allowed' | 'policy_denied' | 'override_allowed'
+ *     policyBasis:  string
+ *   }
+ */
+function checkAndEnforcePolicy(context) {
+  const resolvedContext = {
+    ...context,
+    correlationId: context.correlationId || generateCorrelationId()
+  };
+
+  const decision = evaluatePolicy(resolvedContext.toolName, {
+    allowDestructive: resolvedContext.allowDestructive
+  });
+
+  if (!decision.allowed) {
+    try {
+      const event = buildToolDenialEvent(resolvedContext, decision);
+      submit(event);
+    } catch (err) {
+      record(err, {
+        toolName: resolvedContext.toolName,
+        reason: decision.reason
+      });
+    }
+  }
+
+  return decision;
+}
+
+module.exports = { emitToolInvocation, withToolInstrumentation, emitSessionStart, emitSessionEnd, withSession, emitSecretRetrieval, checkAndEnforcePolicy };

--- a/src/policy/policy-gate.js
+++ b/src/policy/policy-gate.js
@@ -1,0 +1,106 @@
+'use strict';
+
+/**
+ * Home MCP Compliance Lab — Policy Gate (CTRL-HMCP-000002)
+ *
+ * Evaluates whether a tool invocation is permitted under current policy.
+ *
+ * Current policy: DESTRUCTIVE tools with allowed_by_default=false are denied
+ * unless an explicit override is active in the execution context.
+ *
+ * This module is pure — it reads registry and override state, returns a
+ * decision, and emits nothing. Side effects (audit emission) happen in the
+ * caller (see emitter/index.js checkAndEnforcePolicy).
+ *
+ * Override mechanism:
+ *   Pass { allowDestructive: true } in the execution context, or set the
+ *   environment variable HMCP_ALLOW_DESTRUCTIVE=true. Both are intentional
+ *   acts; neither is ever the default. Either can be removed to restore
+ *   deny-by-default behavior without code changes.
+ *
+ * Decision result shape:
+ *   {
+ *     allowed:      boolean   — whether execution may proceed
+ *     toolName:     string
+ *     riskLevel:    string|null
+ *     reason:       string    — 'allowed' | 'policy_denied' | 'override_allowed'
+ *     policyBasis:  string    — short machine-readable explanation
+ *   }
+ */
+
+const path = require('path');
+
+const REGISTRY_PATH = path.resolve(__dirname, '../../config/tool-classifications.json');
+
+let _fullRegistry = null;
+
+function loadFullRegistry() {
+  if (_fullRegistry !== null) return _fullRegistry;
+  try {
+    const entries = require(REGISTRY_PATH);
+    _fullRegistry = {};
+    for (const entry of entries) {
+      if (entry.tool_name) {
+        _fullRegistry[entry.tool_name] = entry;
+      }
+    }
+  } catch (_) {
+    _fullRegistry = {};
+  }
+  return _fullRegistry;
+}
+
+/**
+ * Evaluates policy for a single tool invocation.
+ *
+ * @param {string} toolName
+ * @param {object} [executionContext={}]
+ *   executionContext.allowDestructive {boolean} — explicit per-call override
+ * @returns {{ allowed: boolean, toolName: string, riskLevel: string|null, reason: string, policyBasis: string }}
+ */
+function evaluatePolicy(toolName, executionContext) {
+  const ctx = executionContext || {};
+  const registry = loadFullRegistry();
+  const entry = registry[toolName] || null;
+
+  const riskLevel = entry ? entry.risk_level : null;
+  const allowedByDefault = entry ? entry.allowed_by_default : true;
+
+  // Only DESTRUCTIVE + not allowed_by_default triggers enforcement.
+  const subjectToEnforcement = riskLevel === 'DESTRUCTIVE' && !allowedByDefault;
+
+  if (!subjectToEnforcement) {
+    return {
+      allowed: true,
+      toolName,
+      riskLevel,
+      reason: 'allowed',
+      policyBasis: riskLevel ? `${riskLevel}_tool_allowed` : 'unclassified_tool_allowed'
+    };
+  }
+
+  // Check for an active override.
+  const overrideEnabled =
+    ctx.allowDestructive === true ||
+    process.env.HMCP_ALLOW_DESTRUCTIVE === 'true';
+
+  if (overrideEnabled) {
+    return {
+      allowed: true,
+      toolName,
+      riskLevel,
+      reason: 'override_allowed',
+      policyBasis: 'destructive_tool_allowed_by_explicit_override'
+    };
+  }
+
+  return {
+    allowed: false,
+    toolName,
+    riskLevel,
+    reason: 'policy_denied',
+    policyBasis: 'destructive_tool_not_allowed_by_default'
+  };
+}
+
+module.exports = { evaluatePolicy };

--- a/tests/validate-policy-gate.js
+++ b/tests/validate-policy-gate.js
@@ -1,0 +1,247 @@
+'use strict';
+
+// Validation tests for CTRL-HMCP-000002 — Deny Destructive Tools by Default
+//
+// Validates:
+//   1. Policy gate decisions — allowed, denied, override paths
+//   2. checkAndEnforcePolicy integration — decision shape and denial emission
+//   3. Non-destructive and unknown tools are unaffected
+//   4. Regression: existing emitter public API exports unchanged
+//
+// No network required. Run: node tests/validate-policy-gate.js
+
+const assert = require('assert');
+
+let passed = 0;
+let failed = 0;
+
+async function test(name, fn) {
+  try {
+    await fn();
+    console.log(`  [PASS] ${name}`);
+    passed++;
+  } catch (err) {
+    console.error(`  [FAIL] ${name}: ${err.message}`);
+    failed++;
+  }
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+// Suppress JSONL fallback write output during tests.
+process.env.HMCP_ALLOW_DESTRUCTIVE = undefined;
+delete process.env.HMCP_ALLOW_DESTRUCTIVE;
+
+// ── 1. Policy gate — evaluatePolicy ─────────────────────────────────────────
+
+(async () => {
+
+  console.log('\n1. evaluatePolicy — decision correctness');
+
+  const { evaluatePolicy } = require('../src/policy/policy-gate');
+
+  await test('LOW tool is allowed', async () => {
+    const d = evaluatePolicy('search_repositories', {});
+    assert.strictEqual(d.allowed, true);
+    assert.strictEqual(d.riskLevel, 'LOW');
+    assert.strictEqual(d.reason, 'allowed');
+  });
+
+  await test('MEDIUM tool is allowed', async () => {
+    const d = evaluatePolicy('get_file_contents', {});
+    assert.strictEqual(d.allowed, true);
+    assert.strictEqual(d.riskLevel, 'MEDIUM');
+    assert.strictEqual(d.reason, 'allowed');
+  });
+
+  await test('HIGH tool with allowed_by_default=true is allowed', async () => {
+    const d = evaluatePolicy('create_issue', {});
+    assert.strictEqual(d.allowed, true);
+    assert.strictEqual(d.riskLevel, 'HIGH');
+    assert.strictEqual(d.reason, 'allowed');
+  });
+
+  await test('HIGH tool with allowed_by_default=false (merge_pull_request) is allowed — HIGH not subject to enforcement', async () => {
+    // merge_pull_request is HIGH + allowed_by_default=false, but enforcement is DESTRUCTIVE only
+    const d = evaluatePolicy('merge_pull_request', {});
+    assert.strictEqual(d.allowed, true);
+    assert.strictEqual(d.riskLevel, 'HIGH');
+    assert.strictEqual(d.reason, 'allowed');
+  });
+
+  await test('DESTRUCTIVE tool (delete_branch) is denied by default', async () => {
+    const d = evaluatePolicy('delete_branch', {});
+    assert.strictEqual(d.allowed, false);
+    assert.strictEqual(d.riskLevel, 'DESTRUCTIVE');
+    assert.strictEqual(d.reason, 'policy_denied');
+    assert.strictEqual(d.policyBasis, 'destructive_tool_not_allowed_by_default');
+  });
+
+  await test('unknown tool is allowed (unclassified — not subject to enforcement)', async () => {
+    const d = evaluatePolicy('some_unknown_tool', {});
+    assert.strictEqual(d.allowed, true);
+    assert.strictEqual(d.riskLevel, null);
+    assert.strictEqual(d.reason, 'allowed');
+    assert.strictEqual(d.policyBasis, 'unclassified_tool_allowed');
+  });
+
+  await test('null tool name is allowed (degenerate input)', async () => {
+    const d = evaluatePolicy(null, {});
+    assert.strictEqual(d.allowed, true);
+  });
+
+  // ── 2. Override paths ────────────────────────────────────────────────────
+
+  console.log('\n2. Override paths');
+
+  await test('context allowDestructive=true allows DESTRUCTIVE tool', async () => {
+    const d = evaluatePolicy('delete_branch', { allowDestructive: true });
+    assert.strictEqual(d.allowed, true);
+    assert.strictEqual(d.reason, 'override_allowed');
+    assert.strictEqual(d.policyBasis, 'destructive_tool_allowed_by_explicit_override');
+  });
+
+  await test('env var HMCP_ALLOW_DESTRUCTIVE=true allows DESTRUCTIVE tool', async () => {
+    process.env.HMCP_ALLOW_DESTRUCTIVE = 'true';
+    // Require fresh copy since module caches registry but reads env at call time
+    const key = require.resolve('../src/policy/policy-gate');
+    delete require.cache[key];
+    const { evaluatePolicy: evalFresh } = require('../src/policy/policy-gate');
+    const d = evalFresh('delete_branch', {});
+    delete process.env.HMCP_ALLOW_DESTRUCTIVE;
+    // restore original module
+    delete require.cache[require.resolve('../src/policy/policy-gate')];
+    assert.strictEqual(d.allowed, true);
+    assert.strictEqual(d.reason, 'override_allowed');
+  });
+
+  await test('allowDestructive=false does not override deny', async () => {
+    const d = evaluatePolicy('delete_branch', { allowDestructive: false });
+    assert.strictEqual(d.allowed, false);
+    assert.strictEqual(d.reason, 'policy_denied');
+  });
+
+  await test('missing context object treated as no override', async () => {
+    const d = evaluatePolicy('delete_branch');
+    assert.strictEqual(d.allowed, false);
+    assert.strictEqual(d.reason, 'policy_denied');
+  });
+
+  // ── 3. checkAndEnforcePolicy integration ────────────────────────────────
+
+  console.log('\n3. checkAndEnforcePolicy — integration');
+
+  const { checkAndEnforcePolicy } = require('../src/emitter/index');
+
+  const baseCtx = {
+    projectId: 'home-mcp-lab',
+    agentId: 'test-agent',
+    mcpServer: 'github-mcp-server',
+    correlationId: 'test-corr-001'
+  };
+
+  await test('non-destructive tool returns allowed decision without throwing', async () => {
+    const d = checkAndEnforcePolicy({ ...baseCtx, toolName: 'get_me' });
+    assert.strictEqual(d.allowed, true);
+    assert.strictEqual(d.toolName, 'get_me');
+  });
+
+  await test('destructive tool returns denied decision without throwing', async () => {
+    const d = checkAndEnforcePolicy({ ...baseCtx, toolName: 'delete_branch' });
+    assert.strictEqual(d.allowed, false);
+    assert.strictEqual(d.reason, 'policy_denied');
+  });
+
+  await test('destructive tool with allowDestructive=true returns override_allowed', async () => {
+    const d = checkAndEnforcePolicy({ ...baseCtx, toolName: 'delete_branch', allowDestructive: true });
+    assert.strictEqual(d.allowed, true);
+    assert.strictEqual(d.reason, 'override_allowed');
+  });
+
+  await test('decision includes riskLevel and policyBasis', async () => {
+    const d = checkAndEnforcePolicy({ ...baseCtx, toolName: 'delete_branch' });
+    assert.strictEqual(d.riskLevel, 'DESTRUCTIVE');
+    assert.ok(d.policyBasis, 'Expected policyBasis to be present');
+  });
+
+  await test('correlationId is generated when absent', async () => {
+    const ctx = { projectId: 'p', agentId: 'a', mcpServer: 's', toolName: 'get_me' };
+    const d = checkAndEnforcePolicy(ctx);
+    assert.strictEqual(d.allowed, true);
+  });
+
+  // ── 4. buildToolDenialEvent — event structure ────────────────────────────
+
+  console.log('\n4. buildToolDenialEvent — event structure');
+
+  const { buildToolDenialEvent } = require('../src/emitter/event-builder');
+
+  await test('denial event has correct event_type and status', async () => {
+    const event = buildToolDenialEvent(
+      { toolName: 'delete_branch', projectId: 'p', agentId: 'a', mcpServer: 's', correlationId: 'c' },
+      { riskLevel: 'DESTRUCTIVE', reason: 'policy_denied', policyBasis: 'destructive_tool_not_allowed_by_default' }
+    );
+    assert.strictEqual(event.event_type, 'tool.denial');
+    assert.strictEqual(event.status, 'failure');
+    assert.strictEqual(event.action, 'delete_branch');
+  });
+
+  await test('denial event metadata includes required fields', async () => {
+    const event = buildToolDenialEvent(
+      { toolName: 'delete_branch', projectId: 'p', agentId: 'a', mcpServer: 's', correlationId: 'c' },
+      { riskLevel: 'DESTRUCTIVE', reason: 'policy_denied', policyBasis: 'destructive_tool_not_allowed_by_default' }
+    );
+    assert.strictEqual(event.metadata.tool_name, 'delete_branch');
+    assert.strictEqual(event.metadata.risk_level, 'DESTRUCTIVE');
+    assert.strictEqual(event.metadata.denial_reason, 'policy_denied');
+    assert.strictEqual(event.metadata.policy_basis, 'destructive_tool_not_allowed_by_default');
+  });
+
+  await test('denial event includes initiating_context when supplied', async () => {
+    const event = buildToolDenialEvent(
+      { toolName: 'delete_branch', projectId: 'p', agentId: 'a', mcpServer: 's', correlationId: 'c', initiatingContext: 'CC-HMCP-000010' },
+      { riskLevel: 'DESTRUCTIVE', reason: 'policy_denied', policyBasis: 'destructive_tool_not_allowed_by_default' }
+    );
+    assert.strictEqual(event.metadata.initiating_context, 'CC-HMCP-000010');
+  });
+
+  await test('buildToolDenialEvent throws on missing required context field', async () => {
+    assert.throws(() => {
+      buildToolDenialEvent(
+        { toolName: 'delete_branch', projectId: 'p', agentId: 'a', mcpServer: 's' }, // missing correlationId
+        { riskLevel: 'DESTRUCTIVE', reason: 'policy_denied', policyBasis: 'x' }
+      );
+    }, /Missing required emitter context field/);
+  });
+
+  // ── 5. Regression: existing emitter API ──────────────────────────────────
+
+  console.log('\n5. Regression: existing emitter public API');
+
+  await test('emitter exports unchanged plus checkAndEnforcePolicy', async () => {
+    const emitter = require('../src/emitter/index');
+    const expected = [
+      'emitToolInvocation',
+      'withToolInstrumentation',
+      'emitSessionStart',
+      'emitSessionEnd',
+      'withSession',
+      'emitSecretRetrieval',
+      'checkAndEnforcePolicy'
+    ];
+    for (const fn of expected) {
+      assert.strictEqual(typeof emitter[fn], 'function', `Expected emitter.${fn} to be a function`);
+    }
+  });
+
+  // ── Summary ───────────────────────────────────────────────────────────────
+
+  const bar = '─'.repeat(40);
+  console.log(`\n${bar}`);
+  console.log(`Results: ${passed} passed, ${failed} failed`);
+  if (failed > 0) process.exit(1);
+
+})().catch(err => {
+  console.error('\nValidation script crashed:', err.message);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- Introduces `src/policy/policy-gate.js` — pure policy decision module; evaluates tool risk and override state; returns a structured decision without emitting or throwing
- Adds `checkAndEnforcePolicy(context)` to `src/emitter/index.js` — the callable enforcement boundary; emits `tool.denial` when denied; returns decision to caller
- Adds `buildToolDenialEvent` to `src/emitter/event-builder.js` — builds the `tool.denial` audit event conforming to the existing schema shape
- Adds `tool.denial` event type to `schemas/audit-event.schema.json` — schema-documented alongside existing event types
- Creates `docs/controls/deny-destructive-tools-by-default.md` — documents deny behavior, override paths, denial result shape, audit evidence, and relationship to CTRL-HMCP-000001 and future CTRL-HMCP-000003
- Adds `tests/validate-policy-gate.js` — 21 tests covering all policy paths, override mechanisms, event structure, and regression

## Files Changed

| File | Type | Change |
|---|---|---|
| `src/policy/policy-gate.js` | new | Policy decision module; `evaluatePolicy(toolName, context)` |
| `src/emitter/index.js` | modified | Imports policy-gate; adds `checkAndEnforcePolicy`; exports updated |
| `src/emitter/event-builder.js` | modified | Adds `buildToolDenialEvent`; exports updated |
| `schemas/audit-event.schema.json` | modified | Adds `tool.denial` to `event_type` enum and definitions |
| `docs/controls/deny-destructive-tools-by-default.md` | new | Full control documentation |
| `tests/validate-policy-gate.js` | new | 21 tests; all pass |

## Validation Results

```
1. evaluatePolicy — decision correctness      7/7 pass
2. Override paths                             4/4 pass
3. checkAndEnforcePolicy — integration        5/5 pass
4. buildToolDenialEvent — event structure     4/4 pass
5. Regression: existing emitter public API    1/1 pass

Results: 21 passed, 0 failed
```

Demonstrated:
1. Non-destructive tools (LOW, MEDIUM, HIGH+allowed) pass without change
2. `delete_branch` (DESTRUCTIVE, allowed_by_default=false) is denied by default
3. Denial emits a `tool.denial` audit event with tool name, risk level, denial reason, and policy basis
4. `allowDestructive: true` in context or `HMCP_ALLOW_DESTRUCTIVE=true` env var explicitly overrides deny
5. Unknown tools are allowed (unclassified — outside enforcement scope)

Pre-existing unrelated failures: the `@modelcontextprotocol/sdk` dependency is absent on this machine, causing 8 transport-layer tests in `validate-mcp-transport.js` to fail. These are unchanged from before this task.

Executed: CC-HMCP-000010

🤖 Generated with [Claude Code](https://claude.com/claude-code)