### PR TITLE
feat: implement approval-required tool execution (CTRL-HMCP-000003)

### DIFF
--- a/docs/controls/approval-required-tool-execution.md
+++ b/docs/controls/approval-required-tool-execution.md
@@ -1,0 +1,222 @@
+# CTRL-HMCP-000003 — Approval-Required Tool Execution
+
+## Control Summary
+
+| Field | Value |
+|---|---|
+| Control ID | CTRL-HMCP-000003 |
+| Implemented by | CC-HMCP-000011 |
+| Status | Active |
+| Enforcement tier | Tier 2 (HIGH tools) |
+| Depends on | CTRL-HMCP-000001 (Tool Risk Classification), CTRL-HMCP-000002 (Deny Destructive Tools by Default) |
+
+---
+
+## Purpose
+
+Extends the policy gate introduced in CTRL-HMCP-000002 with a second enforcement tier for `HIGH` risk tools that have `allowed_by_default: false`.
+
+Where CTRL-HMCP-000002 denies `DESTRUCTIVE` tools outright, this control blocks `HIGH` tools pending an explicit, auditable approval signal. The distinction is intentional:
+
+- `DESTRUCTIVE` tools are categorically blocked unless overridden (no routine approval path)
+- `HIGH` tools with `allowed_by_default: false` require deliberate approval before each execution, producing audit evidence
+
+---
+
+## Enforcement Model
+
+### Two-Tier Policy Gate
+
+The policy gate (`src/policy/policy-gate.js`) evaluates tools in tier order:
+
+**Tier 1 — DESTRUCTIVE (CTRL-HMCP-000002)**
+- Applies to: `risk_level = DESTRUCTIVE` AND `allowed_by_default = false`
+- Default outcome: `policy_denied` — outright denial, no approval path
+- Override: `allowDestructive: true` in context, or `HMCP_ALLOW_DESTRUCTIVE=true` env var
+
+**Tier 2 — HIGH approval-required (CTRL-HMCP-000003)**
+- Applies to: `risk_level = HIGH` AND `allowed_by_default = false`
+- Default outcome: `requires_approval` — execution blocked pending approval
+- Approval: `approvalGranted: true` in context, or `HMCP_APPROVAL_GRANTED=true` env var
+
+Tools that match neither tier proceed normally (`allowed`).
+
+---
+
+## Which Tools Require Approval
+
+Approval is required for tools registered in `config/tool-classifications.json` with:
+- `risk_level: "HIGH"`
+- `allowed_by_default: false`
+
+**Current approval-required tools:**
+
+| Tool | Risk Level | Rationale |
+|---|---|---|
+| `merge_pull_request` | HIGH | Integrates changes into target branch; affects production branches if unscoped; reversible only via revert |
+
+Tools with `risk_level: "HIGH"` and `allowed_by_default: true` (e.g., `create_issue`, `create_or_update_file`, `update_pull_request`) are **not** subject to this control — they execute normally without an approval signal.
+
+---
+
+## Decision Result Shape
+
+### When approval is required but not satisfied
+
+```json
+{
+  "allowed": false,
+  "toolName": "merge_pull_request",
+  "riskLevel": "HIGH",
+  "reason": "requires_approval",
+  "policyBasis": "high_risk_tool_requires_approval",
+  "approvalRequired": true,
+  "approvalSatisfied": false,
+  "approvalMechanism": null
+}
+```
+
+### When approval is explicitly satisfied
+
+```json
+{
+  "allowed": true,
+  "toolName": "merge_pull_request",
+  "riskLevel": "HIGH",
+  "reason": "approved",
+  "policyBasis": "high_risk_tool_allowed_by_explicit_approval",
+  "approvalRequired": true,
+  "approvalSatisfied": true,
+  "approvalMechanism": "context_flag"
+}
+```
+
+`reason` values introduced by this control: `requires_approval` | `approved`
+
+Full `reason` vocabulary (all tiers):
+`allowed` | `policy_denied` | `override_allowed` | `requires_approval` | `approved`
+
+---
+
+## How Approval Is Satisfied
+
+Two mechanisms, both intentional acts — neither is ever the default.
+
+### 1. Per-call context flag
+
+Pass `approvalGranted: true` in the context object passed to `checkAndEnforcePolicy`:
+
+```js
+const decision = checkAndEnforcePolicy({
+  toolName: 'merge_pull_request',
+  projectId: 'home-mcp-lab',
+  agentId: 'claude-code-session',
+  mcpServer: 'github-mcp-server',
+  correlationId: 'sess-20260407-abc123',
+  approvalGranted: true   // explicit approval for this call
+});
+
+if (decision.allowed) {
+  // proceed with tool execution
+}
+```
+
+Produces `approvalMechanism: 'context_flag'` in the decision and audit event.
+
+### 2. Environment variable
+
+Set `HMCP_APPROVAL_GRANTED=true` in the process environment. Applies for the lifetime of the process.
+
+```bash
+HMCP_APPROVAL_GRANTED=true node my-script.js
+```
+
+Produces `approvalMechanism: 'env_var'` in the decision and audit event.
+
+Removing either mechanism restores the approval-required behavior with no code changes.
+
+---
+
+## Audit Events
+
+### tool.denial — approval pending
+
+Emitted when the tool is blocked by this control (`requires_approval`). Includes `approval_required: true` in metadata to distinguish from outright denial (`policy_denied`).
+
+```json
+{
+  "event_type": "tool.denial",
+  "action": "merge_pull_request",
+  "status": "failure",
+  "metadata": {
+    "tool_name": "merge_pull_request",
+    "risk_level": "HIGH",
+    "denial_reason": "requires_approval",
+    "policy_basis": "high_risk_tool_requires_approval",
+    "approval_required": true
+  }
+}
+```
+
+### tool.approval_granted — approval satisfied
+
+Emitted when approval is explicitly satisfied and execution is permitted. Precedes the `tool.invocation` event for the same call.
+
+```json
+{
+  "event_type": "tool.approval_granted",
+  "action": "merge_pull_request",
+  "status": "success",
+  "metadata": {
+    "tool_name": "merge_pull_request",
+    "risk_level": "HIGH",
+    "policy_basis": "high_risk_tool_allowed_by_explicit_approval",
+    "approval_mechanism": "context_flag"
+  }
+}
+```
+
+### tool.invocation — normal execution event
+
+After `tool.approval_granted`, the instrumentation layer emits a standard `tool.invocation` event on completion. Both events share the same `correlation_id`.
+
+---
+
+## Integration Pattern
+
+```
+caller calls checkAndEnforcePolicy(context)
+  └── policy gate evaluates tier 2 rule
+        ├── approval missing  → returns { allowed: false, reason: 'requires_approval' }
+        │                        emits tool.denial (denial_reason: 'requires_approval')
+        └── approval present  → returns { allowed: true, reason: 'approved' }
+                                 emits tool.approval_granted
+                                 caller proceeds → emits tool.invocation
+```
+
+The caller is always responsible for gating execution on `decision.allowed`. The policy gate never invokes or blocks the tool directly.
+
+---
+
+## Relationship to Other Controls
+
+| Control | Scope | Outcome when triggered |
+|---|---|---|
+| CTRL-HMCP-000001 | Classifies tools by risk level | Provides input to enforcement |
+| CTRL-HMCP-000002 | DESTRUCTIVE + `allowed_by_default=false` | Outright denial (`policy_denied`) |
+| CTRL-HMCP-000003 (this) | HIGH + `allowed_by_default=false` | Blocked pending approval (`requires_approval`) or explicitly allowed (`approved`) |
+
+Tier 1 is evaluated before tier 2. A tool cannot simultaneously trigger both tiers.
+
+---
+
+## Future Extension Points
+
+This control is designed to be tightened without architectural changes:
+
+- Narrow approval scope: add per-tool approval checks (rather than per-risk-level)
+- Strengthen approval mechanism: replace env var with a token, signed payload, or external authorization call
+- Add expiry: scope approval to a session or time window
+- Add multi-step: require approval from a second party before `approvalGranted` is populated
+
+None of these require changes to the decision shape or audit schema. The `approvalMechanism` field in `tool.approval_granted` events provides a hook for distinguishing mechanism types as they evolve.

--- a/schemas/audit-event.schema.json
+++ b/schemas/audit-event.schema.json
@@ -38,7 +38,7 @@
     "event_type": {
       "type": "string",
       "description": "Categorizes the event. See defined event types below.",
-      "enum": ["tool.invocation", "tool.denial", "secret.retrieval", "session.start", "session.end"],
+      "enum": ["tool.invocation", "tool.denial", "tool.approval_granted", "secret.retrieval", "session.start", "session.end"],
       "example": "tool.invocation"
     },
 
@@ -114,12 +114,24 @@
     },
 
     "event_type.tool.denial": {
-      "description": "Emitted when a tool invocation is blocked by the platform policy gate before execution begins. The tool is never invoked. Emitted with status:'failure'.",
+      "description": "Emitted when a tool invocation is blocked by the platform policy gate before execution begins. The tool is never invoked. Emitted with status:'failure'. Covers both outright denial (DESTRUCTIVE tier) and approval-pending denial (HIGH tier).",
       "metadata_fields": {
         "tool_name": "string — name of the tool that was denied",
         "risk_level": "string — risk classification at the time of denial: 'LOW' | 'MEDIUM' | 'HIGH' | 'DESTRUCTIVE' | 'UNKNOWN'",
-        "denial_reason": "string — machine-readable denial reason; currently 'policy_denied'",
-        "policy_basis": "string — machine-readable explanation of the policy that caused the denial (e.g. 'destructive_tool_not_allowed_by_default')",
+        "denial_reason": "string — machine-readable denial reason: 'policy_denied' (DESTRUCTIVE tier, CTRL-HMCP-000002) | 'requires_approval' (HIGH tier, CTRL-HMCP-000003)",
+        "policy_basis": "string — machine-readable explanation of the policy that caused the denial (e.g. 'destructive_tool_not_allowed_by_default', 'high_risk_tool_requires_approval')",
+        "approval_required": "boolean (optional) — true when denial_reason is 'requires_approval'; indicates the tool can proceed if approval is explicitly satisfied",
+        "initiating_context": "string (optional) — prompt ID or workflow context if available"
+      }
+    },
+
+    "event_type.tool.approval_granted": {
+      "description": "Emitted when a HIGH approval-required tool is allowed because an explicit approval signal was satisfied (CTRL-HMCP-000003). This event precedes the tool.invocation event for the same tool call. Emitted with status:'success'.",
+      "metadata_fields": {
+        "tool_name": "string — name of the tool whose approval was granted",
+        "risk_level": "string — risk classification: expected 'HIGH' for this event type",
+        "policy_basis": "string — machine-readable explanation: 'high_risk_tool_allowed_by_explicit_approval'",
+        "approval_mechanism": "string — how approval was satisfied: 'context_flag' (approvalGranted=true in call context) | 'env_var' (HMCP_APPROVAL_GRANTED=true)",
         "initiating_context": "string (optional) — prompt ID or workflow context if available"
       }
     },

--- a/src/emitter/event-builder.js
+++ b/src/emitter/event-builder.js
@@ -245,6 +245,9 @@ function buildSecretRetrievalEvent(context, outcome) {
  * Required decision fields (from policy-gate evaluatePolicy result):
  *   riskLevel, reason, policyBasis
  *
+ * Optional decision fields:
+ *   approvalRequired (boolean) — included in metadata when present
+ *
  * Throws if any required field is missing.
  */
 function buildToolDenialEvent(context, decision) {
@@ -261,6 +264,10 @@ function buildToolDenialEvent(context, decision) {
     denial_reason: decision.reason,
     policy_basis: decision.policyBasis
   };
+
+  if (decision.approvalRequired != null) {
+    metadata.approval_required = decision.approvalRequired;
+  }
 
   if (context.initiatingContext) {
     metadata.initiating_context = context.initiatingContext;
@@ -282,4 +289,53 @@ function buildToolDenialEvent(context, decision) {
   };
 }
 
-module.exports = { buildToolInvocationEvent, buildSessionStartEvent, buildSessionEndEvent, buildSecretRetrievalEvent, buildToolDenialEvent };
+/**
+ * Builds a schema-conforming tool.approval_granted audit event.
+ *
+ * Emitted when a HIGH approval-required tool is allowed because an explicit
+ * approval signal was satisfied (CTRL-HMCP-000003).
+ *
+ * Required context fields:
+ *   toolName, projectId, agentId, mcpServer, correlationId
+ *
+ * Required decision fields (from policy-gate evaluatePolicy result):
+ *   riskLevel, reason ('approved'), policyBasis, approvalMechanism
+ *
+ * Throws if any required field is missing.
+ */
+function buildToolApprovalGrantedEvent(context, decision) {
+  const required = ['toolName', 'projectId', 'agentId', 'mcpServer', 'correlationId'];
+  for (const field of required) {
+    if (!context[field]) {
+      throw new Error(`Missing required emitter context field: ${field}`);
+    }
+  }
+
+  const metadata = {
+    tool_name: context.toolName,
+    risk_level: decision.riskLevel || 'UNKNOWN',
+    policy_basis: decision.policyBasis,
+    approval_mechanism: decision.approvalMechanism || 'unknown'
+  };
+
+  if (context.initiatingContext) {
+    metadata.initiating_context = context.initiatingContext;
+  }
+
+  return {
+    schema_version: SCHEMA_VERSION,
+    event_id: randomUUID(),
+    event_type: 'tool.approval_granted',
+    timestamp: new Date().toISOString(),
+    platform: PLATFORM,
+    project_id: context.projectId,
+    agent_id: context.agentId,
+    mcp_server: context.mcpServer,
+    action: context.toolName,
+    status: 'success',
+    correlation_id: context.correlationId,
+    metadata
+  };
+}
+
+module.exports = { buildToolInvocationEvent, buildSessionStartEvent, buildSessionEndEvent, buildSecretRetrievalEvent, buildToolDenialEvent, buildToolApprovalGrantedEvent };

--- a/src/emitter/index.js
+++ b/src/emitter/index.js
@@ -12,7 +12,7 @@
  *   withToolInstrumentation(context, fn)   — wrap an async tool call with instrumentation
  *   emitSessionStart(context)              — emit session.start directly; returns correlationId
  *   emitSessionEnd(context, outcome)       — emit session.end directly
- *   checkAndEnforcePolicy(context)         — evaluate policy; emit tool.denial if denied; returns decision
+ *   checkAndEnforcePolicy(context)         — evaluate policy; emit tool.denial or tool.approval_granted; returns decision
  *
  * Context shape:
  *   toolName           string  required  — MCP tool name (e.g. "create_issue")
@@ -27,7 +27,7 @@
  */
 
 const { randomUUID } = require('crypto');
-const { buildToolInvocationEvent, buildSessionStartEvent, buildSessionEndEvent, buildSecretRetrievalEvent, buildToolDenialEvent } = require('./event-builder');
+const { buildToolInvocationEvent, buildSessionStartEvent, buildSessionEndEvent, buildSecretRetrievalEvent, buildToolDenialEvent, buildToolApprovalGrantedEvent } = require('./event-builder');
 const { submit } = require('./transport');
 const { record } = require('./failure-observer');
 const { lookupRiskLevel } = require('./classification-registry');
@@ -263,23 +263,33 @@ function emitSecretRetrieval(context, outcome) {
 }
 
 /**
- * Evaluate policy for a tool and emit a tool.denial event if denied.
+ * Evaluate policy for a tool and emit audit events for all enforcement outcomes.
  *
  * Returns a decision object. When allowed === false, the tool must not be
  * invoked — the caller is responsible for gating execution on this result.
  *
- * Never throws — denial emission failures are handled by the failure observer.
+ * Never throws — emission failures are handled by the failure observer.
+ *
+ * Enforcement tiers:
+ *   Tier 1 (DESTRUCTIVE): denied outright; tool.denial emitted with reason 'policy_denied'.
+ *   Tier 1 override: allowed via allowDestructive; no additional event emitted.
+ *   Tier 2 (HIGH, approval-required): blocked; tool.denial emitted with reason 'requires_approval'.
+ *   Tier 2 approved: allowed; tool.approval_granted emitted with mechanism captured.
  *
  * context shape — same as emitToolInvocation context plus:
- *   allowDestructive  boolean  optional  — per-call explicit override; default false
+ *   allowDestructive  boolean  optional  — per-call explicit destructive override (tier 1); default false
+ *   approvalGranted   boolean  optional  — per-call explicit approval (tier 2); default false
  *
  * Returned decision shape:
  *   {
- *     allowed:      boolean
- *     toolName:     string
- *     riskLevel:    string|null
- *     reason:       'allowed' | 'policy_denied' | 'override_allowed'
- *     policyBasis:  string
+ *     allowed:           boolean
+ *     toolName:          string
+ *     riskLevel:         string|null
+ *     reason:            'allowed' | 'policy_denied' | 'override_allowed' | 'requires_approval' | 'approved'
+ *     policyBasis:       string
+ *     approvalRequired:  boolean   (present for HIGH tier-2 tools)
+ *     approvalSatisfied: boolean   (present for HIGH tier-2 tools)
+ *     approvalMechanism: string|null (present for HIGH tier-2 tools when approved)
  *   }
  */
 function checkAndEnforcePolicy(context) {
@@ -289,12 +299,25 @@ function checkAndEnforcePolicy(context) {
   };
 
   const decision = evaluatePolicy(resolvedContext.toolName, {
-    allowDestructive: resolvedContext.allowDestructive
+    allowDestructive: resolvedContext.allowDestructive,
+    approvalGranted: resolvedContext.approvalGranted
   });
 
   if (!decision.allowed) {
+    // Covers both 'policy_denied' (tier 1) and 'requires_approval' (tier 2).
     try {
       const event = buildToolDenialEvent(resolvedContext, decision);
+      submit(event);
+    } catch (err) {
+      record(err, {
+        toolName: resolvedContext.toolName,
+        reason: decision.reason
+      });
+    }
+  } else if (decision.reason === 'approved') {
+    // Tier 2 approval granted — emit explicit audit evidence.
+    try {
+      const event = buildToolApprovalGrantedEvent(resolvedContext, decision);
       submit(event);
     } catch (err) {
       record(err, {

--- a/src/policy/policy-gate.js
+++ b/src/policy/policy-gate.js
@@ -1,31 +1,45 @@
 'use strict';
 
 /**
- * Home MCP Compliance Lab — Policy Gate (CTRL-HMCP-000002)
+ * Home MCP Compliance Lab — Policy Gate (CTRL-HMCP-000002 / CTRL-HMCP-000003)
  *
  * Evaluates whether a tool invocation is permitted under current policy.
  *
- * Current policy: DESTRUCTIVE tools with allowed_by_default=false are denied
- * unless an explicit override is active in the execution context.
+ * Enforcement tiers (evaluated in order):
  *
- * This module is pure — it reads registry and override state, returns a
- * decision, and emits nothing. Side effects (audit emission) happen in the
+ *   TIER 1 — DESTRUCTIVE tools (CTRL-HMCP-000002)
+ *     Tools with risk_level='DESTRUCTIVE' and allowed_by_default=false are
+ *     denied outright unless the explicit destructive override is active.
+ *     Override: context.allowDestructive=true or HMCP_ALLOW_DESTRUCTIVE=true.
+ *
+ *   TIER 2 — HIGH approval-required tools (CTRL-HMCP-000003)
+ *     Tools with risk_level='HIGH' and allowed_by_default=false require an
+ *     explicit approval signal. Without it, execution is blocked (reason:
+ *     'requires_approval'). With it, execution is allowed (reason: 'approved').
+ *     Approval: context.approvalGranted=true or HMCP_APPROVAL_GRANTED=true.
+ *
+ * This module is pure — it reads registry and override/approval state, returns
+ * a decision, and emits nothing. Side effects (audit emission) happen in the
  * caller (see emitter/index.js checkAndEnforcePolicy).
- *
- * Override mechanism:
- *   Pass { allowDestructive: true } in the execution context, or set the
- *   environment variable HMCP_ALLOW_DESTRUCTIVE=true. Both are intentional
- *   acts; neither is ever the default. Either can be removed to restore
- *   deny-by-default behavior without code changes.
  *
  * Decision result shape:
  *   {
- *     allowed:      boolean   — whether execution may proceed
- *     toolName:     string
- *     riskLevel:    string|null
- *     reason:       string    — 'allowed' | 'policy_denied' | 'override_allowed'
- *     policyBasis:  string    — short machine-readable explanation
+ *     allowed:           boolean        — whether execution may proceed
+ *     toolName:          string
+ *     riskLevel:         string|null
+ *     reason:            string         — see reason values below
+ *     policyBasis:       string         — short machine-readable explanation
+ *     approvalRequired:  boolean        — true when tier-2 applies (present only for HIGH tier-2 tools)
+ *     approvalSatisfied: boolean        — true when approval was explicitly granted (present only for HIGH tier-2 tools)
+ *     approvalMechanism: string|null    — 'context_flag' | 'env_var' | null (present only when approvalSatisfied=true)
  *   }
+ *
+ * Reason values:
+ *   'allowed'             — tool is permitted (no enforcement triggered)
+ *   'policy_denied'       — DESTRUCTIVE tool denied outright (tier 1)
+ *   'override_allowed'    — DESTRUCTIVE tool allowed via explicit override (tier 1)
+ *   'requires_approval'   — HIGH tool blocked; approval not satisfied (tier 2)
+ *   'approved'            — HIGH tool allowed; approval explicitly satisfied (tier 2)
  */
 
 const path = require('path');
@@ -55,8 +69,9 @@ function loadFullRegistry() {
  *
  * @param {string} toolName
  * @param {object} [executionContext={}]
- *   executionContext.allowDestructive {boolean} — explicit per-call override
- * @returns {{ allowed: boolean, toolName: string, riskLevel: string|null, reason: string, policyBasis: string }}
+ *   executionContext.allowDestructive  {boolean} — explicit per-call override (tier 1)
+ *   executionContext.approvalGranted   {boolean} — explicit per-call approval (tier 2)
+ * @returns {{ allowed: boolean, toolName: string, riskLevel: string|null, reason: string, policyBasis: string, approvalRequired?: boolean, approvalSatisfied?: boolean, approvalMechanism?: string|null }}
  */
 function evaluatePolicy(toolName, executionContext) {
   const ctx = executionContext || {};
@@ -66,40 +81,76 @@ function evaluatePolicy(toolName, executionContext) {
   const riskLevel = entry ? entry.risk_level : null;
   const allowedByDefault = entry ? entry.allowed_by_default : true;
 
-  // Only DESTRUCTIVE + not allowed_by_default triggers enforcement.
-  const subjectToEnforcement = riskLevel === 'DESTRUCTIVE' && !allowedByDefault;
+  // ── Tier 1: DESTRUCTIVE tools ──────────────────────────────────────────────
 
-  if (!subjectToEnforcement) {
+  const subjectToDestructiveEnforcement = riskLevel === 'DESTRUCTIVE' && !allowedByDefault;
+
+  if (subjectToDestructiveEnforcement) {
+    const overrideEnabled =
+      ctx.allowDestructive === true ||
+      process.env.HMCP_ALLOW_DESTRUCTIVE === 'true';
+
+    if (overrideEnabled) {
+      return {
+        allowed: true,
+        toolName,
+        riskLevel,
+        reason: 'override_allowed',
+        policyBasis: 'destructive_tool_allowed_by_explicit_override'
+      };
+    }
+
     return {
-      allowed: true,
+      allowed: false,
       toolName,
       riskLevel,
-      reason: 'allowed',
-      policyBasis: riskLevel ? `${riskLevel}_tool_allowed` : 'unclassified_tool_allowed'
+      reason: 'policy_denied',
+      policyBasis: 'destructive_tool_not_allowed_by_default'
     };
   }
 
-  // Check for an active override.
-  const overrideEnabled =
-    ctx.allowDestructive === true ||
-    process.env.HMCP_ALLOW_DESTRUCTIVE === 'true';
+  // ── Tier 2: HIGH approval-required tools ──────────────────────────────────
 
-  if (overrideEnabled) {
+  const subjectToApprovalEnforcement = riskLevel === 'HIGH' && !allowedByDefault;
+
+  if (subjectToApprovalEnforcement) {
+    const approvalViaCFlag = ctx.approvalGranted === true;
+    const approvalViaEnvVar = process.env.HMCP_APPROVAL_GRANTED === 'true';
+    const approvalSatisfied = approvalViaCFlag || approvalViaEnvVar;
+
+    if (approvalSatisfied) {
+      return {
+        allowed: true,
+        toolName,
+        riskLevel,
+        reason: 'approved',
+        policyBasis: 'high_risk_tool_allowed_by_explicit_approval',
+        approvalRequired: true,
+        approvalSatisfied: true,
+        approvalMechanism: approvalViaCFlag ? 'context_flag' : 'env_var'
+      };
+    }
+
     return {
-      allowed: true,
+      allowed: false,
       toolName,
       riskLevel,
-      reason: 'override_allowed',
-      policyBasis: 'destructive_tool_allowed_by_explicit_override'
+      reason: 'requires_approval',
+      policyBasis: 'high_risk_tool_requires_approval',
+      approvalRequired: true,
+      approvalSatisfied: false,
+      approvalMechanism: null
     };
   }
+
+  // ── Default: tool is allowed ───────────────────────────────────────────────
 
   return {
-    allowed: false,
+    allowed: true,
     toolName,
     riskLevel,
-    reason: 'policy_denied',
-    policyBasis: 'destructive_tool_not_allowed_by_default'
+    reason: 'allowed',
+    policyBasis: riskLevel ? `${riskLevel}_tool_allowed` : 'unclassified_tool_allowed'
   };
 }
 

--- a/tests/validate-approval-gate.js
+++ b/tests/validate-approval-gate.js
@@ -1,0 +1,285 @@
+'use strict';
+
+// Validation tests for CTRL-HMCP-000003 — Approval-Required Tool Execution
+//
+// Validates:
+//   1. evaluatePolicy — approval-required decisions for HIGH tier-2 tools
+//   2. evaluatePolicy — approval satisfaction paths (context flag, env var)
+//   3. evaluatePolicy — tier-1 DESTRUCTIVE behavior unchanged
+//   4. checkAndEnforcePolicy — integration; audit events for all enforcement outcomes
+//   5. buildToolApprovalGrantedEvent — event structure
+//   6. Regression: tier-1 (CTRL-HMCP-000002) behavior unaffected
+//
+// No network required. Run: node tests/validate-approval-gate.js
+
+const assert = require('assert');
+
+let passed = 0;
+let failed = 0;
+
+async function test(name, fn) {
+  try {
+    await fn();
+    console.log(`  [PASS] ${name}`);
+    passed++;
+  } catch (err) {
+    console.error(`  [FAIL] ${name}: ${err.message}`);
+    failed++;
+  }
+}
+
+// ── Setup ─────────────────────────────────────────────────────────────────────
+
+// Ensure no approval or destructive env vars are set at start.
+delete process.env.HMCP_APPROVAL_GRANTED;
+delete process.env.HMCP_ALLOW_DESTRUCTIVE;
+
+// ── 1. Tier-2 approval-required decisions ─────────────────────────────────────
+
+(async () => {
+
+  console.log('\n1. evaluatePolicy — HIGH tier-2 approval-required decisions');
+
+  const { evaluatePolicy } = require('../src/policy/policy-gate');
+
+  await test('HIGH + allowed_by_default=false blocked without approval (requires_approval)', async () => {
+    const d = evaluatePolicy('merge_pull_request', {});
+    assert.strictEqual(d.allowed, false);
+    assert.strictEqual(d.riskLevel, 'HIGH');
+    assert.strictEqual(d.reason, 'requires_approval');
+    assert.strictEqual(d.policyBasis, 'high_risk_tool_requires_approval');
+    assert.strictEqual(d.approvalRequired, true);
+    assert.strictEqual(d.approvalSatisfied, false);
+    assert.strictEqual(d.approvalMechanism, null);
+  });
+
+  await test('HIGH + allowed_by_default=true is allowed normally (no tier-2 enforcement)', async () => {
+    // create_issue is HIGH + allowed_by_default=true — no approval required
+    const d = evaluatePolicy('create_issue', {});
+    assert.strictEqual(d.allowed, true);
+    assert.strictEqual(d.riskLevel, 'HIGH');
+    assert.strictEqual(d.reason, 'allowed');
+    assert.strictEqual(d.approvalRequired, undefined);
+  });
+
+  // ── 2. Approval satisfaction paths ────────────────────────────────────────
+
+  console.log('\n2. evaluatePolicy — approval satisfaction paths');
+
+  await test('context approvalGranted=true satisfies approval (approved via context_flag)', async () => {
+    const d = evaluatePolicy('merge_pull_request', { approvalGranted: true });
+    assert.strictEqual(d.allowed, true);
+    assert.strictEqual(d.riskLevel, 'HIGH');
+    assert.strictEqual(d.reason, 'approved');
+    assert.strictEqual(d.policyBasis, 'high_risk_tool_allowed_by_explicit_approval');
+    assert.strictEqual(d.approvalRequired, true);
+    assert.strictEqual(d.approvalSatisfied, true);
+    assert.strictEqual(d.approvalMechanism, 'context_flag');
+  });
+
+  await test('env var HMCP_APPROVAL_GRANTED=true satisfies approval (approved via env_var)', async () => {
+    process.env.HMCP_APPROVAL_GRANTED = 'true';
+    const key = require.resolve('../src/policy/policy-gate');
+    delete require.cache[key];
+    const { evaluatePolicy: evalFresh } = require('../src/policy/policy-gate');
+    const d = evalFresh('merge_pull_request', {});
+    delete process.env.HMCP_APPROVAL_GRANTED;
+    delete require.cache[require.resolve('../src/policy/policy-gate')];
+    assert.strictEqual(d.allowed, true);
+    assert.strictEqual(d.reason, 'approved');
+    assert.strictEqual(d.approvalMechanism, 'env_var');
+  });
+
+  await test('approvalGranted=false does not satisfy approval', async () => {
+    const d = evaluatePolicy('merge_pull_request', { approvalGranted: false });
+    assert.strictEqual(d.allowed, false);
+    assert.strictEqual(d.reason, 'requires_approval');
+  });
+
+  await test('approvalGranted=true does not affect DESTRUCTIVE tool (tiers are independent)', async () => {
+    // approvalGranted=true should not allow a DESTRUCTIVE tool — that requires allowDestructive
+    const d = evaluatePolicy('delete_branch', { approvalGranted: true });
+    assert.strictEqual(d.allowed, false);
+    assert.strictEqual(d.reason, 'policy_denied');
+  });
+
+  await test('allowDestructive=true does not satisfy HIGH approval requirement', async () => {
+    // allowDestructive applies only to tier-1; HIGH tier-2 requires approvalGranted
+    const d = evaluatePolicy('merge_pull_request', { allowDestructive: true });
+    assert.strictEqual(d.allowed, false);
+    assert.strictEqual(d.reason, 'requires_approval');
+  });
+
+  // ── 3. Tier-1 DESTRUCTIVE behavior unchanged ──────────────────────────────
+
+  console.log('\n3. evaluatePolicy — tier-1 DESTRUCTIVE behavior unchanged (CTRL-HMCP-000002 regression)');
+
+  await test('DESTRUCTIVE tool denied by default', async () => {
+    const d = evaluatePolicy('delete_branch', {});
+    assert.strictEqual(d.allowed, false);
+    assert.strictEqual(d.reason, 'policy_denied');
+    assert.strictEqual(d.policyBasis, 'destructive_tool_not_allowed_by_default');
+    assert.strictEqual(d.approvalRequired, undefined);
+  });
+
+  await test('DESTRUCTIVE tool allowed with allowDestructive=true (override_allowed)', async () => {
+    const d = evaluatePolicy('delete_branch', { allowDestructive: true });
+    assert.strictEqual(d.allowed, true);
+    assert.strictEqual(d.reason, 'override_allowed');
+  });
+
+  await test('LOW tool unaffected', async () => {
+    const d = evaluatePolicy('get_me', {});
+    assert.strictEqual(d.allowed, true);
+    assert.strictEqual(d.reason, 'allowed');
+    assert.strictEqual(d.approvalRequired, undefined);
+  });
+
+  await test('unknown tool unaffected', async () => {
+    const d = evaluatePolicy('some_unregistered_tool', {});
+    assert.strictEqual(d.allowed, true);
+    assert.strictEqual(d.reason, 'allowed');
+    assert.strictEqual(d.policyBasis, 'unclassified_tool_allowed');
+  });
+
+  // ── 4. checkAndEnforcePolicy integration ──────────────────────────────────
+
+  console.log('\n4. checkAndEnforcePolicy — integration');
+
+  const { checkAndEnforcePolicy } = require('../src/emitter/index');
+
+  const baseCtx = {
+    projectId: 'home-mcp-lab',
+    agentId: 'test-agent',
+    mcpServer: 'github-mcp-server',
+    correlationId: 'test-corr-approval-001'
+  };
+
+  await test('LOW tool returns allowed without throwing', async () => {
+    const d = checkAndEnforcePolicy({ ...baseCtx, toolName: 'get_me' });
+    assert.strictEqual(d.allowed, true);
+    assert.strictEqual(d.reason, 'allowed');
+  });
+
+  await test('HIGH approval-required tool returns requires_approval decision', async () => {
+    const d = checkAndEnforcePolicy({ ...baseCtx, toolName: 'merge_pull_request' });
+    assert.strictEqual(d.allowed, false);
+    assert.strictEqual(d.reason, 'requires_approval');
+    assert.strictEqual(d.approvalRequired, true);
+    assert.strictEqual(d.approvalSatisfied, false);
+  });
+
+  await test('HIGH approval-required tool with approvalGranted=true returns approved', async () => {
+    const d = checkAndEnforcePolicy({ ...baseCtx, toolName: 'merge_pull_request', approvalGranted: true });
+    assert.strictEqual(d.allowed, true);
+    assert.strictEqual(d.reason, 'approved');
+    assert.strictEqual(d.approvalSatisfied, true);
+    assert.strictEqual(d.approvalMechanism, 'context_flag');
+  });
+
+  await test('DESTRUCTIVE tool still denied (tier-1 unaffected)', async () => {
+    const d = checkAndEnforcePolicy({ ...baseCtx, toolName: 'delete_branch' });
+    assert.strictEqual(d.allowed, false);
+    assert.strictEqual(d.reason, 'policy_denied');
+  });
+
+  await test('DESTRUCTIVE tool with allowDestructive=true still returns override_allowed', async () => {
+    const d = checkAndEnforcePolicy({ ...baseCtx, toolName: 'delete_branch', allowDestructive: true });
+    assert.strictEqual(d.allowed, true);
+    assert.strictEqual(d.reason, 'override_allowed');
+  });
+
+  await test('decision includes riskLevel and policyBasis for requires_approval', async () => {
+    const d = checkAndEnforcePolicy({ ...baseCtx, toolName: 'merge_pull_request' });
+    assert.strictEqual(d.riskLevel, 'HIGH');
+    assert.ok(d.policyBasis, 'Expected policyBasis to be present');
+  });
+
+  await test('correlationId is generated when absent', async () => {
+    const ctx = { projectId: 'p', agentId: 'a', mcpServer: 's', toolName: 'merge_pull_request' };
+    const d = checkAndEnforcePolicy(ctx);
+    assert.strictEqual(d.allowed, false);
+    assert.strictEqual(d.reason, 'requires_approval');
+  });
+
+  // ── 5. buildToolApprovalGrantedEvent — event structure ───────────────────
+
+  console.log('\n5. buildToolApprovalGrantedEvent — event structure');
+
+  const { buildToolApprovalGrantedEvent } = require('../src/emitter/event-builder');
+
+  await test('approval_granted event has correct event_type and status', async () => {
+    const event = buildToolApprovalGrantedEvent(
+      { toolName: 'merge_pull_request', projectId: 'p', agentId: 'a', mcpServer: 's', correlationId: 'c' },
+      { riskLevel: 'HIGH', reason: 'approved', policyBasis: 'high_risk_tool_allowed_by_explicit_approval', approvalMechanism: 'context_flag' }
+    );
+    assert.strictEqual(event.event_type, 'tool.approval_granted');
+    assert.strictEqual(event.status, 'success');
+    assert.strictEqual(event.action, 'merge_pull_request');
+  });
+
+  await test('approval_granted event metadata includes required fields', async () => {
+    const event = buildToolApprovalGrantedEvent(
+      { toolName: 'merge_pull_request', projectId: 'p', agentId: 'a', mcpServer: 's', correlationId: 'c' },
+      { riskLevel: 'HIGH', reason: 'approved', policyBasis: 'high_risk_tool_allowed_by_explicit_approval', approvalMechanism: 'env_var' }
+    );
+    assert.strictEqual(event.metadata.tool_name, 'merge_pull_request');
+    assert.strictEqual(event.metadata.risk_level, 'HIGH');
+    assert.strictEqual(event.metadata.policy_basis, 'high_risk_tool_allowed_by_explicit_approval');
+    assert.strictEqual(event.metadata.approval_mechanism, 'env_var');
+  });
+
+  await test('approval_granted event includes initiating_context when supplied', async () => {
+    const event = buildToolApprovalGrantedEvent(
+      { toolName: 'merge_pull_request', projectId: 'p', agentId: 'a', mcpServer: 's', correlationId: 'c', initiatingContext: 'CC-HMCP-000011' },
+      { riskLevel: 'HIGH', reason: 'approved', policyBasis: 'high_risk_tool_allowed_by_explicit_approval', approvalMechanism: 'context_flag' }
+    );
+    assert.strictEqual(event.metadata.initiating_context, 'CC-HMCP-000011');
+  });
+
+  await test('buildToolApprovalGrantedEvent throws on missing required context field', async () => {
+    assert.throws(() => {
+      buildToolApprovalGrantedEvent(
+        { toolName: 'merge_pull_request', projectId: 'p', agentId: 'a', mcpServer: 's' }, // missing correlationId
+        { riskLevel: 'HIGH', reason: 'approved', policyBasis: 'x', approvalMechanism: 'context_flag' }
+      );
+    }, /Missing required emitter context field/);
+  });
+
+  await test('buildToolDenialEvent includes approval_required=true for requires_approval decision', async () => {
+    const { buildToolDenialEvent } = require('../src/emitter/event-builder');
+    const event = buildToolDenialEvent(
+      { toolName: 'merge_pull_request', projectId: 'p', agentId: 'a', mcpServer: 's', correlationId: 'c' },
+      { riskLevel: 'HIGH', reason: 'requires_approval', policyBasis: 'high_risk_tool_requires_approval', approvalRequired: true }
+    );
+    assert.strictEqual(event.event_type, 'tool.denial');
+    assert.strictEqual(event.status, 'failure');
+    assert.strictEqual(event.metadata.denial_reason, 'requires_approval');
+    assert.strictEqual(event.metadata.approval_required, true);
+  });
+
+  // ── 6. Regression: CTRL-HMCP-000002 denial events unchanged ──────────────
+
+  console.log('\n6. Regression — CTRL-HMCP-000002 denial event shape unchanged');
+
+  await test('DESTRUCTIVE denial event has no approval_required field', async () => {
+    const { buildToolDenialEvent } = require('../src/emitter/event-builder');
+    const event = buildToolDenialEvent(
+      { toolName: 'delete_branch', projectId: 'p', agentId: 'a', mcpServer: 's', correlationId: 'c' },
+      { riskLevel: 'DESTRUCTIVE', reason: 'policy_denied', policyBasis: 'destructive_tool_not_allowed_by_default' }
+    );
+    assert.strictEqual(event.metadata.denial_reason, 'policy_denied');
+    assert.strictEqual(event.metadata.approval_required, undefined);
+  });
+
+  // ── Summary ───────────────────────────────────────────────────────────────
+
+  const bar = '─'.repeat(40);
+  console.log(`\n${bar}`);
+  console.log(`Results: ${passed} passed, ${failed} failed`);
+  if (failed > 0) process.exit(1);
+
+})().catch(err => {
+  console.error('\nValidation script crashed:', err.message);
+  process.exit(1);
+});

--- a/tests/validate-policy-gate.js
+++ b/tests/validate-policy-gate.js
@@ -61,12 +61,14 @@ delete process.env.HMCP_ALLOW_DESTRUCTIVE;
     assert.strictEqual(d.reason, 'allowed');
   });
 
-  await test('HIGH tool with allowed_by_default=false (merge_pull_request) is allowed — HIGH not subject to enforcement', async () => {
-    // merge_pull_request is HIGH + allowed_by_default=false, but enforcement is DESTRUCTIVE only
+  await test('HIGH tool with allowed_by_default=false (merge_pull_request) requires approval — CTRL-HMCP-000003', async () => {
+    // merge_pull_request is HIGH + allowed_by_default=false; subject to tier-2 approval enforcement
     const d = evaluatePolicy('merge_pull_request', {});
-    assert.strictEqual(d.allowed, true);
+    assert.strictEqual(d.allowed, false);
     assert.strictEqual(d.riskLevel, 'HIGH');
-    assert.strictEqual(d.reason, 'allowed');
+    assert.strictEqual(d.reason, 'requires_approval');
+    assert.strictEqual(d.approvalRequired, true);
+    assert.strictEqual(d.approvalSatisfied, false);
   });
 
   await test('DESTRUCTIVE tool (delete_branch) is denied by default', async () => {


### PR DESCRIPTION
## Summary

- Extends the policy gate with a second enforcement tier (Tier 2) for `HIGH` tools with `allowed_by_default: false`
- `merge_pull_request` now requires explicit approval before execution; blocked with `reason: requires_approval` when missing
- Approval satisfied via `approvalGranted: true` context flag or `HMCP_APPROVAL_GRANTED=true` env var; produces auditable `tool.approval_granted` event
- Tier 1 DESTRUCTIVE behavior (CTRL-HMCP-000002) is fully preserved and regression-tested

## Changes

- `src/policy/policy-gate.js` — tiered enforcement logic; new reason values `requires_approval` / `approved`; `approvalMechanism` field in decision shape
- `src/emitter/event-builder.js` — extended `buildToolDenialEvent` with `approval_required` metadata; new `buildToolApprovalGrantedEvent`
- `src/emitter/index.js` — wired `approvalGranted` into `checkAndEnforcePolicy`; emits `tool.approval_granted` on approved path
- `schemas/audit-event.schema.json` — added `tool.approval_granted` event type; updated `tool.denial` definition for new `denial_reason` values
- `tests/validate-approval-gate.js` — 24 new tests (all pass)
- `tests/validate-policy-gate.js` — updated `merge_pull_request` test to reflect new approval-required behavior (21 tests pass)
- `docs/controls/approval-required-tool-execution.md` — full control documentation

## Test plan

- [x] `node tests/validate-approval-gate.js` — 24 passed, 0 failed
- [x] `node tests/validate-policy-gate.js` — 21 passed, 0 failed

Implements: CC-HMCP-000011 / CTRL-HMCP-000003

🤖 Generated with [Claude Code](https://claude.com/claude-code)