### PR TITLE
feat: implement event completeness validation (TD-HMCP-000003)

### DIFF
--- a/docs/detection/event-completeness-validation.md
+++ b/docs/detection/event-completeness-validation.md
@@ -1,0 +1,187 @@
+# Event Completeness Validation — TD-HMCP-000003
+
+## Purpose
+
+The event completeness validator examines a sequence of audit events and determines whether the trace is complete enough to be trustworthy — that is, whether the events represent a valid, audit-grade record of what occurred.
+
+Completeness validation answers the question:
+
+> "Given this set of events, is the audit record complete, or are there gaps that indicate something is missing?"
+
+This is the first step toward audit trust. Without completeness guarantees, downstream consumers (anomaly detection, compliance reporting, incident review) cannot reliably interpret a trace.
+
+---
+
+## What Completeness Validation Is Checking
+
+The validator evaluates five rule groups:
+
+### Rule 1 — Field Integrity
+
+Every audit event must contain all required top-level fields as defined in `schemas/audit-event.schema.json`:
+
+`event_id`, `event_type`, `timestamp`, `correlation_id`, `project_id`, `agent_id`, `mcp_server`, `action`, `status`, `metadata`
+
+An event missing any of these fields cannot be fully interpreted by the platform or downstream consumers.
+
+Issue code: `missing_required_field`
+
+---
+
+### Rule 2 — Session Coverage
+
+A complete session trace must be framed by start and end events:
+
+- If session-activity events are present (`tool.invocation`, `tool.denial`, `tool.approval_granted`, `secret.retrieval`), a `session.start` event must exist.
+- If `session.start` is present, a `session.end` event must also be present.
+
+A trace without session framing cannot be correlated to a session lifecycle and cannot be verified as complete.
+
+Issue codes: `missing_session_start`, `missing_session_end`
+
+---
+
+### Rule 3 — Correlation Consistency
+
+When a trace contains exactly one `session.start` and one `session.end`, both must share the same `correlation_id`. If they differ, the end event belongs to a different session than the start event, indicating a corrupted or mis-assembled trace.
+
+Issue code: `inconsistent_session_correlation`
+
+---
+
+### Rule 4 — Approval Path Completeness
+
+A `tool.approval_granted` event signals that approval was explicitly satisfied for a tool. If the tool is approved but never invoked, the trace is incomplete — either the invocation was not recorded, or something prevented execution after approval.
+
+Every `tool.approval_granted` event must have a corresponding `tool.invocation` event for the same tool and same `correlation_id`.
+
+Issue code: `approval_without_invocation`
+
+---
+
+### Rule 5 — Approval Evidence for Invocations
+
+Tools that require approval before execution (`risk_level=HIGH`, `allowed_by_default=false` in `config/tool-classifications.json`) must have a `tool.approval_granted` event in the trace before their `tool.invocation`. An invocation without prior approval evidence indicates the approval gate may have been bypassed or the approval event was not captured.
+
+Currently approval-required tools: `merge_pull_request`
+
+Issue code: `missing_approval_evidence`
+
+---
+
+## What Completeness Validation Is NOT Checking
+
+This validator does not:
+
+- **Detect behavioral anomalies** — it does not flag unusual call sequences, abnormal volumes, or suspicious patterns. That is future work.
+- **Verify semantic correctness** — it does not check whether tool arguments were appropriate or whether outcomes were expected.
+- **Enforce ordering within a session** — events are checked for presence, not strict sequence (except approval → invocation pairing).
+- **Validate multi-session traces** — the validator is designed for a single-session trace. Multi-session traces are outside the current scope.
+- **Check timestamp ordering** — events are not validated for chronological consistency.
+- **Verify external state** — it does not cross-reference event data against the GitHub API or other external systems.
+
+---
+
+## Completeness Rules Summary
+
+| Rule | Issue Code | Trigger Condition |
+|---|---|---|
+| Field integrity | `missing_required_field` | Required field absent or empty on any event |
+| Session coverage | `missing_session_start` | Session-activity events present, no `session.start` |
+| Session coverage | `missing_session_end` | `session.start` present, no `session.end` |
+| Correlation consistency | `inconsistent_session_correlation` | `session.start` and `session.end` have different `correlation_id` |
+| Approval path | `approval_without_invocation` | `tool.approval_granted` with no matching `tool.invocation` |
+| Approval evidence | `missing_approval_evidence` | `tool.invocation` for approval-required tool with no `tool.approval_granted` |
+| Invalid input | `invalid_input` | Input is not an array |
+
+---
+
+## Validator Result Shape
+
+```js
+const { validate } = require('./src/detection/event-completeness-validator');
+const result = validate(events);
+```
+
+```json
+{
+  "complete": false,
+  "issues": [
+    {
+      "code": "missing_session_end",
+      "message": "Trace contains session.start but no session.end event",
+      "context": {
+        "correlation_id": "sess-20260407-abc123"
+      }
+    }
+  ],
+  "warnings": []
+}
+```
+
+- `complete: true` — no issues found; trace is audit-complete per current rules
+- `complete: false` — one or more issues found; trace should not be trusted as complete
+- `issues` — completeness failures; each issue has a stable `code`, human-readable `message`, and optional `context`
+- `warnings` — advisory findings (reserved for future use; currently empty)
+
+---
+
+## Stable Issue Codes
+
+Issue codes are exported as `ISSUE_CODES` from the validator module for use by downstream consumers:
+
+```js
+const { ISSUE_CODES } = require('./src/detection/event-completeness-validator');
+// ISSUE_CODES.MISSING_SESSION_START === 'missing_session_start'
+```
+
+| Constant | Code |
+|---|---|
+| `INVALID_INPUT` | `invalid_input` |
+| `MISSING_REQUIRED_FIELD` | `missing_required_field` |
+| `MISSING_SESSION_START` | `missing_session_start` |
+| `MISSING_SESSION_END` | `missing_session_end` |
+| `INCONSISTENT_SESSION_CORRELATION` | `inconsistent_session_correlation` |
+| `APPROVAL_WITHOUT_INVOCATION` | `approval_without_invocation` |
+| `MISSING_APPROVAL_EVIDENCE` | `missing_approval_evidence` |
+
+---
+
+## How This Supports Future Work
+
+### Anomaly Detection
+
+Completeness validation is a prerequisite for anomaly detection. A trace cannot be analyzed for behavioral anomalies until it is known to be structurally complete. Future anomaly detection rules will rely on the completeness validator as a pre-filter.
+
+### Audit Trust
+
+Compliance reporting and incident review require a guarantee that the event record is complete. The `complete: true` result provides a machine-readable signal that a trace meets the minimum bar for audit use.
+
+### Sequence-Based Control Verification
+
+Future rules can extend the validator to check event ordering (e.g., "approval must precede invocation chronologically") and sequence patterns (e.g., "session must end within N minutes of last activity").
+
+### Correlation Integrity
+
+Future rules can extend correlation checking to verify that all tool events within a session share the session's `correlation_id`, not just the start/end events.
+
+---
+
+## Relationship to Platform Controls
+
+| Component | Role |
+|---|---|
+| `CTRL-HMCP-000001` | Provides risk classifications used by Rule 5 (approval evidence check) |
+| `CTRL-HMCP-000002` | Produces `tool.denial` events; denial sessions are valid complete traces |
+| `CTRL-HMCP-000003` | Produces `tool.approval_granted` events; approval paths validated by Rules 4 and 5 |
+| `TD-HMCP-000003` (this) | Validates that the events produced by the above controls are complete |
+
+---
+
+## Module Location
+
+```
+src/detection/event-completeness-validator.js
+```
+
+Tests: `tests/validate-event-completeness.js`

--- a/src/detection/event-completeness-validator.js
+++ b/src/detection/event-completeness-validator.js
@@ -1,0 +1,369 @@
+'use strict';
+
+/**
+ * Home MCP Compliance Lab — Event Completeness Validator (TD-HMCP-000003)
+ *
+ * Validates whether a sequence of audit events constitutes a complete,
+ * trustworthy trace according to the platform's completeness rules.
+ *
+ * Rules evaluated:
+ *   1. Field integrity     — required fields present on every event
+ *   2. Session coverage    — session.start / session.end pairing
+ *   3. Correlation consistency — session.start and session.end share correlation_id
+ *   4. Approval path       — tool.approval_granted has a matching tool.invocation
+ *   5. Approval evidence   — tool.invocation for approval-required tools has a
+ *                            preceding tool.approval_granted
+ *
+ * Pure module — reads the classification registry (file I/O only); returns
+ * a structured result with no side effects.
+ *
+ * Usage:
+ *   const { validate } = require('./event-completeness-validator');
+ *   const result = validate(events);
+ *   // { complete: boolean, issues: Array<Issue>, warnings: Array<Warning> }
+ *
+ * Result shape:
+ *   {
+ *     complete:  boolean   — true only when issues is empty
+ *     issues:    Issue[]   — completeness failures; trace should not be trusted
+ *     warnings:  Warning[] — advisory findings; trace may be acceptable
+ *   }
+ *
+ * Issue shape:
+ *   {
+ *     code:     string   — stable machine-readable code (see ISSUE_CODES)
+ *     message:  string   — human-readable description
+ *     context:  object   — optional — event_id, tool_name, field, etc.
+ *   }
+ */
+
+const path = require('path');
+
+// ── Constants ───────────────────────────────────────────────────────────────
+
+/**
+ * Stable issue codes for completeness failures.
+ * These codes are intended to be referenced by downstream consumers.
+ */
+const ISSUE_CODES = {
+  INVALID_INPUT:                  'invalid_input',
+  MISSING_REQUIRED_FIELD:         'missing_required_field',
+  MISSING_SESSION_START:          'missing_session_start',
+  MISSING_SESSION_END:            'missing_session_end',
+  INCONSISTENT_SESSION_CORRELATION: 'inconsistent_session_correlation',
+  APPROVAL_WITHOUT_INVOCATION:    'approval_without_invocation',
+  MISSING_APPROVAL_EVIDENCE:      'missing_approval_evidence',
+};
+
+// Required top-level fields per audit-event.schema.json v0.2.0
+const REQUIRED_FIELDS = [
+  'event_id',
+  'event_type',
+  'timestamp',
+  'correlation_id',
+  'project_id',
+  'agent_id',
+  'mcp_server',
+  'action',
+  'status',
+  'metadata',
+];
+
+// Event types that are session-scoped and require a session.start wrapper
+const SESSION_ACTIVITY_TYPES = new Set([
+  'tool.invocation',
+  'tool.denial',
+  'tool.approval_granted',
+  'secret.retrieval',
+]);
+
+// ── Classification registry ─────────────────────────────────────────────────
+
+let _classificationRegistry = null;
+
+function loadClassificationRegistry() {
+  if (_classificationRegistry !== null) return _classificationRegistry;
+  try {
+    const entries = require(path.resolve(__dirname, '../../config/tool-classifications.json'));
+    _classificationRegistry = {};
+    for (const entry of entries) {
+      if (entry.tool_name) _classificationRegistry[entry.tool_name] = entry;
+    }
+  } catch (_) {
+    _classificationRegistry = {};
+  }
+  return _classificationRegistry;
+}
+
+function toolRequiresApproval(toolName) {
+  const registry = loadClassificationRegistry();
+  const entry = registry[toolName];
+  return !!(entry && entry.risk_level === 'HIGH' && entry.allowed_by_default === false);
+}
+
+// ── Issue / warning factories ────────────────────────────────────────────────
+
+function mkIssue(code, message, context) {
+  const result = { code, message };
+  if (context != null) result.context = context;
+  return result;
+}
+
+function mkWarning(code, message, context) {
+  const result = { code, message };
+  if (context != null) result.context = context;
+  return result;
+}
+
+// ── Helper: extract tool name from an event ──────────────────────────────────
+
+function toolNameOf(event) {
+  return (event.metadata && event.metadata.tool_name) || event.action || null;
+}
+
+// ── Rules ────────────────────────────────────────────────────────────────────
+
+/**
+ * Rule 1 — Field Integrity
+ *
+ * Every event must contain all required top-level fields with non-null,
+ * non-empty values. The metadata field must be an object.
+ *
+ * Issues: missing_required_field
+ */
+function checkRequiredFields(events) {
+  const issues = [];
+  for (const evt of events) {
+    for (const field of REQUIRED_FIELDS) {
+      const value = evt[field];
+      const isMissing =
+        value == null ||
+        value === '' ||
+        (field === 'metadata' && (typeof value !== 'object' || Array.isArray(value)));
+
+      if (isMissing) {
+        issues.push(mkIssue(
+          ISSUE_CODES.MISSING_REQUIRED_FIELD,
+          `Event is missing required field: "${field}"`,
+          {
+            event_id:   evt.event_id   || '(unknown)',
+            event_type: evt.event_type || '(unknown)',
+            field,
+          }
+        ));
+      }
+    }
+  }
+  return { issues, warnings: [] };
+}
+
+/**
+ * Rule 2 — Session Coverage
+ *
+ * A trace that contains session-activity events must be framed by a
+ * session.start event. If session.start is present, session.end is required.
+ *
+ * Issues: missing_session_start, missing_session_end
+ */
+function checkSessionCoverage(events) {
+  const issues = [];
+
+  const hasSessionStart   = events.some(e => e.event_type === 'session.start');
+  const hasSessionEnd     = events.some(e => e.event_type === 'session.end');
+  const activityEvents    = events.filter(e => SESSION_ACTIVITY_TYPES.has(e.event_type));
+  const hasSessionActivity = activityEvents.length > 0;
+
+  if (hasSessionActivity && !hasSessionStart) {
+    issues.push(mkIssue(
+      ISSUE_CODES.MISSING_SESSION_START,
+      'Trace contains session-activity events but no session.start event',
+      { session_activity_count: activityEvents.length }
+    ));
+  }
+
+  if (hasSessionStart && !hasSessionEnd) {
+    const start = events.find(e => e.event_type === 'session.start');
+    issues.push(mkIssue(
+      ISSUE_CODES.MISSING_SESSION_END,
+      'Trace contains session.start but no session.end event',
+      { correlation_id: start ? start.correlation_id : null }
+    ));
+  }
+
+  return { issues, warnings: [] };
+}
+
+/**
+ * Rule 3 — Correlation Consistency
+ *
+ * When a trace contains exactly one session.start and one session.end,
+ * both must share the same correlation_id. Mismatched IDs indicate that
+ * the end event belongs to a different session.
+ *
+ * Issues: inconsistent_session_correlation
+ */
+function checkCorrelationConsistency(events) {
+  const issues = [];
+
+  const starts = events.filter(e => e.event_type === 'session.start');
+  const ends   = events.filter(e => e.event_type === 'session.end');
+
+  if (starts.length === 1 && ends.length === 1) {
+    const startCid = starts[0].correlation_id;
+    const endCid   = ends[0].correlation_id;
+
+    if (startCid && endCid && startCid !== endCid) {
+      issues.push(mkIssue(
+        ISSUE_CODES.INCONSISTENT_SESSION_CORRELATION,
+        'session.start and session.end have different correlation_ids',
+        {
+          session_start_correlation_id: startCid,
+          session_end_correlation_id:   endCid,
+        }
+      ));
+    }
+  }
+
+  return { issues, warnings: [] };
+}
+
+/**
+ * Rule 4 — Approval Path Completeness
+ *
+ * A tool.approval_granted event must be followed by a tool.invocation event
+ * for the same tool within the same correlation scope. If approval was granted
+ * but the tool was never invoked, the trace is incomplete.
+ *
+ * Issues: approval_without_invocation
+ */
+function checkApprovalPathCompleteness(events) {
+  const issues = [];
+  const approvals = events.filter(e => e.event_type === 'tool.approval_granted');
+
+  for (const approval of approvals) {
+    const toolName     = toolNameOf(approval);
+    const correlationId = approval.correlation_id;
+
+    const hasMatchingInvocation = events.some(e =>
+      e.event_type === 'tool.invocation' &&
+      toolNameOf(e) === toolName &&
+      e.correlation_id === correlationId
+    );
+
+    if (!hasMatchingInvocation) {
+      issues.push(mkIssue(
+        ISSUE_CODES.APPROVAL_WITHOUT_INVOCATION,
+        `tool.approval_granted for "${toolName}" has no matching tool.invocation in trace`,
+        {
+          tool_name:      toolName,
+          correlation_id: correlationId,
+          event_id:       approval.event_id,
+        }
+      ));
+    }
+  }
+
+  return { issues, warnings: [] };
+}
+
+/**
+ * Rule 5 — Approval Evidence for Invocations
+ *
+ * A tool.invocation event for a tool that requires approval (HIGH risk level,
+ * allowed_by_default=false) must be preceded by a tool.approval_granted event
+ * for the same tool within the same correlation scope.
+ *
+ * Tools subject to this rule are determined from config/tool-classifications.json.
+ * If the registry cannot be loaded, this rule is skipped gracefully.
+ *
+ * Issues: missing_approval_evidence
+ */
+function checkApprovalEvidenceForInvocations(events) {
+  const issues = [];
+  const invocations = events.filter(e => e.event_type === 'tool.invocation');
+
+  for (const inv of invocations) {
+    const toolName = toolNameOf(inv);
+    if (!toolName || !toolRequiresApproval(toolName)) continue;
+
+    const correlationId = inv.correlation_id;
+
+    const hasApproval = events.some(e =>
+      e.event_type === 'tool.approval_granted' &&
+      toolNameOf(e) === toolName &&
+      e.correlation_id === correlationId
+    );
+
+    if (!hasApproval) {
+      issues.push(mkIssue(
+        ISSUE_CODES.MISSING_APPROVAL_EVIDENCE,
+        `tool.invocation for approval-required tool "${toolName}" has no preceding tool.approval_granted in trace`,
+        {
+          tool_name:      toolName,
+          correlation_id: correlationId,
+          event_id:       inv.event_id,
+        }
+      ));
+    }
+  }
+
+  return { issues, warnings: [] };
+}
+
+// ── Registered ruleset ───────────────────────────────────────────────────────
+
+const RULES = [
+  checkRequiredFields,
+  checkSessionCoverage,
+  checkCorrelationConsistency,
+  checkApprovalPathCompleteness,
+  checkApprovalEvidenceForInvocations,
+];
+
+// ── Validator ────────────────────────────────────────────────────────────────
+
+/**
+ * Validate a sequence of audit events for completeness.
+ *
+ * @param {object[]} events — array of audit event objects
+ * @returns {{ complete: boolean, issues: object[], warnings: object[] }}
+ */
+function validate(events) {
+  if (!Array.isArray(events)) {
+    return {
+      complete: false,
+      issues: [mkIssue(
+        ISSUE_CODES.INVALID_INPUT,
+        'events must be an array',
+        { received: typeof events }
+      )],
+      warnings: [],
+    };
+  }
+
+  const allIssues   = [];
+  const allWarnings = [];
+
+  for (const rule of RULES) {
+    const { issues, warnings } = rule(events);
+    allIssues.push(...issues);
+    allWarnings.push(...warnings);
+  }
+
+  return {
+    complete: allIssues.length === 0,
+    issues:   allIssues,
+    warnings: allWarnings,
+  };
+}
+
+module.exports = {
+  validate,
+  ISSUE_CODES,
+  // Export individual rules for targeted unit testing
+  checkRequiredFields,
+  checkSessionCoverage,
+  checkCorrelationConsistency,
+  checkApprovalPathCompleteness,
+  checkApprovalEvidenceForInvocations,
+};

--- a/tests/validate-event-completeness.js
+++ b/tests/validate-event-completeness.js
@@ -1,0 +1,421 @@
+'use strict';
+
+// Validation tests for TD-HMCP-000003 — Event Completeness Validation
+//
+// Validates:
+//   1. Complete traces are recognized as complete
+//   2. Missing session framing is flagged
+//   3. Correlation inconsistencies are flagged
+//   4. Approval path gaps are flagged
+//   5. Approval evidence gaps are flagged
+//   6. Field integrity failures are flagged
+//   7. Edge cases: empty input, non-array input, unknown tools
+//
+// No network required. Run: node tests/validate-event-completeness.js
+
+const assert = require('assert');
+
+let passed = 0;
+let failed = 0;
+
+async function test(name, fn) {
+  try {
+    await fn();
+    console.log(`  [PASS] ${name}`);
+    passed++;
+  } catch (err) {
+    console.error(`  [FAIL] ${name}: ${err.message}`);
+    failed++;
+  }
+}
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const CID = 'sess-20260407-test001';
+
+// Minimal valid event factory — only sets required fields.
+function evt(overrides) {
+  return {
+    event_id:       `evt-${Math.random().toString(36).slice(2, 9)}`,
+    event_type:     'tool.invocation',
+    timestamp:      '2026-04-07T12:00:00Z',
+    platform:       'home-mcp-lab',
+    project_id:     'home-mcp-lab',
+    agent_id:       'test-agent',
+    mcp_server:     'github-mcp-server',
+    action:         'get_me',
+    status:         'success',
+    correlation_id: CID,
+    metadata:       { tool_name: 'get_me' },
+    ...overrides,
+  };
+}
+
+// Full happy-path session fixture: start → LOW invocation → end
+function happyPathSession() {
+  return [
+    evt({ event_id: 'evt-001', event_type: 'session.start',  action: 'mcp_session_init', metadata: { session_type: 'interactive' } }),
+    evt({ event_id: 'evt-002', event_type: 'tool.invocation', action: 'get_me',           metadata: { tool_name: 'get_me' } }),
+    evt({ event_id: 'evt-003', event_type: 'session.end',    action: 'mcp_session_close', status: 'success', metadata: { completion_reason: 'task_complete' } }),
+  ];
+}
+
+// Approval-required tool (merge_pull_request) — correct approval path
+function approvalGrantedSession() {
+  return [
+    evt({ event_id: 'evt-001', event_type: 'session.start',         action: 'mcp_session_init',  metadata: { session_type: 'interactive' } }),
+    evt({ event_id: 'evt-002', event_type: 'tool.approval_granted', action: 'merge_pull_request', metadata: { tool_name: 'merge_pull_request', risk_level: 'HIGH', policy_basis: 'high_risk_tool_allowed_by_explicit_approval', approval_mechanism: 'context_flag' } }),
+    evt({ event_id: 'evt-003', event_type: 'tool.invocation',       action: 'merge_pull_request', metadata: { tool_name: 'merge_pull_request', risk_level: 'HIGH' } }),
+    evt({ event_id: 'evt-004', event_type: 'session.end',           action: 'mcp_session_close',  metadata: { completion_reason: 'task_complete' } }),
+  ];
+}
+
+// Denial-only session (tool.denial is self-contained evidence)
+function denialSession() {
+  return [
+    evt({ event_id: 'evt-001', event_type: 'session.start', action: 'mcp_session_init', metadata: { session_type: 'interactive' } }),
+    evt({ event_id: 'evt-002', event_type: 'tool.denial',   action: 'delete_branch',    status: 'failure', metadata: { tool_name: 'delete_branch', risk_level: 'DESTRUCTIVE', denial_reason: 'policy_denied', policy_basis: 'destructive_tool_not_allowed_by_default' } }),
+    evt({ event_id: 'evt-003', event_type: 'session.end',   action: 'mcp_session_close', metadata: { completion_reason: 'task_complete' } }),
+  ];
+}
+
+// ── Load validator ─────────────────────────────────────────────────────────────
+
+const {
+  validate,
+  ISSUE_CODES,
+  checkRequiredFields,
+  checkSessionCoverage,
+  checkCorrelationConsistency,
+  checkApprovalPathCompleteness,
+  checkApprovalEvidenceForInvocations,
+} = require('../src/detection/event-completeness-validator');
+
+// ── 1. Complete traces ─────────────────────────────────────────────────────────
+
+(async () => {
+
+  console.log('\n1. Complete traces — recognized as complete');
+
+  await test('complete happy-path session (start → invocation → end) is complete', async () => {
+    const result = validate(happyPathSession());
+    assert.strictEqual(result.complete, true);
+    assert.strictEqual(result.issues.length, 0);
+  });
+
+  await test('complete approval-path session (start → approval_granted → invocation → end) is complete', async () => {
+    const result = validate(approvalGrantedSession());
+    assert.strictEqual(result.complete, true);
+    assert.strictEqual(result.issues.length, 0);
+  });
+
+  await test('complete denial session (start → tool.denial → end) is complete', async () => {
+    const result = validate(denialSession());
+    assert.strictEqual(result.complete, true);
+    assert.strictEqual(result.issues.length, 0);
+  });
+
+  await test('empty trace is complete (no events — no rule violations)', async () => {
+    const result = validate([]);
+    assert.strictEqual(result.complete, true);
+    assert.strictEqual(result.issues.length, 0);
+  });
+
+  await test('result always has issues and warnings arrays', async () => {
+    const result = validate([]);
+    assert.ok(Array.isArray(result.issues));
+    assert.ok(Array.isArray(result.warnings));
+  });
+
+  // ── 2. Session coverage ────────────────────────────────────────────────────
+
+  console.log('\n2. Session coverage — missing framing');
+
+  await test('missing session.start is flagged when activity events are present', async () => {
+    const events = [
+      evt({ event_id: 'evt-001', event_type: 'tool.invocation', action: 'get_me', metadata: { tool_name: 'get_me' } }),
+      evt({ event_id: 'evt-002', event_type: 'session.end',     action: 'mcp_session_close', metadata: {} }),
+    ];
+    const result = validate(events);
+    assert.strictEqual(result.complete, false);
+    const codes = result.issues.map(i => i.code);
+    assert.ok(codes.includes(ISSUE_CODES.MISSING_SESSION_START), `Expected missing_session_start; got: ${codes}`);
+  });
+
+  await test('missing session.end is flagged when session.start is present', async () => {
+    const events = [
+      evt({ event_id: 'evt-001', event_type: 'session.start',  action: 'mcp_session_init', metadata: {} }),
+      evt({ event_id: 'evt-002', event_type: 'tool.invocation', action: 'get_me',           metadata: { tool_name: 'get_me' } }),
+    ];
+    const result = validate(events);
+    assert.strictEqual(result.complete, false);
+    const codes = result.issues.map(i => i.code);
+    assert.ok(codes.includes(ISSUE_CODES.MISSING_SESSION_END), `Expected missing_session_end; got: ${codes}`);
+  });
+
+  await test('missing_session_end issue includes correlation_id context', async () => {
+    const events = [
+      evt({ event_id: 'evt-001', event_type: 'session.start', action: 'mcp_session_init', metadata: {}, correlation_id: 'sess-test-999' }),
+    ];
+    const result = validate(events);
+    const issue = result.issues.find(i => i.code === ISSUE_CODES.MISSING_SESSION_END);
+    assert.ok(issue, 'Expected missing_session_end issue');
+    assert.strictEqual(issue.context.correlation_id, 'sess-test-999');
+  });
+
+  await test('session without any activity events does not require session.start', async () => {
+    // Only session.start and session.end — no activity — this is fine (no start required by activity rule)
+    const events = [
+      evt({ event_id: 'evt-001', event_type: 'session.start', action: 'mcp_session_init', metadata: {} }),
+      evt({ event_id: 'evt-002', event_type: 'session.end',   action: 'mcp_session_close', metadata: {} }),
+    ];
+    const result = validate(events);
+    // Should pass the session coverage rule (both present)
+    const sessionIssues = result.issues.filter(i =>
+      i.code === ISSUE_CODES.MISSING_SESSION_START || i.code === ISSUE_CODES.MISSING_SESSION_END
+    );
+    assert.strictEqual(sessionIssues.length, 0);
+  });
+
+  await test('tool.denial is a session-activity event and triggers missing_session_start when no start', async () => {
+    const events = [
+      evt({ event_id: 'evt-001', event_type: 'tool.denial', action: 'delete_branch', status: 'failure', metadata: {} }),
+    ];
+    const result = validate(events);
+    const codes = result.issues.map(i => i.code);
+    assert.ok(codes.includes(ISSUE_CODES.MISSING_SESSION_START));
+  });
+
+  // ── 3. Correlation consistency ─────────────────────────────────────────────
+
+  console.log('\n3. Correlation consistency');
+
+  await test('mismatched correlation_id between session.start and session.end is flagged', async () => {
+    const events = [
+      evt({ event_id: 'evt-001', event_type: 'session.start', action: 'mcp_session_init', correlation_id: 'sess-aaa', metadata: {} }),
+      evt({ event_id: 'evt-002', event_type: 'session.end',   action: 'mcp_session_close', correlation_id: 'sess-bbb', metadata: {} }),
+    ];
+    const result = validate(events);
+    assert.strictEqual(result.complete, false);
+    const issue = result.issues.find(i => i.code === ISSUE_CODES.INCONSISTENT_SESSION_CORRELATION);
+    assert.ok(issue, 'Expected inconsistent_session_correlation issue');
+    assert.strictEqual(issue.context.session_start_correlation_id, 'sess-aaa');
+    assert.strictEqual(issue.context.session_end_correlation_id,   'sess-bbb');
+  });
+
+  await test('matching correlation_ids between session.start and session.end is not flagged', async () => {
+    const events = [
+      evt({ event_id: 'evt-001', event_type: 'session.start', action: 'mcp_session_init',  correlation_id: 'sess-same', metadata: {} }),
+      evt({ event_id: 'evt-002', event_type: 'session.end',   action: 'mcp_session_close', correlation_id: 'sess-same', metadata: {} }),
+    ];
+    const result = validate(events);
+    const issue = result.issues.find(i => i.code === ISSUE_CODES.INCONSISTENT_SESSION_CORRELATION);
+    assert.strictEqual(issue, undefined);
+  });
+
+  // ── 4. Approval path completeness ─────────────────────────────────────────
+
+  console.log('\n4. Approval path — approval_without_invocation');
+
+  await test('tool.approval_granted without matching tool.invocation is flagged', async () => {
+    const events = [
+      evt({ event_id: 'evt-001', event_type: 'session.start',         action: 'mcp_session_init',  metadata: {} }),
+      evt({ event_id: 'evt-002', event_type: 'tool.approval_granted', action: 'merge_pull_request', metadata: { tool_name: 'merge_pull_request' } }),
+      // No tool.invocation follows
+      evt({ event_id: 'evt-003', event_type: 'session.end',           action: 'mcp_session_close',  metadata: {} }),
+    ];
+    const result = validate(events);
+    assert.strictEqual(result.complete, false);
+    const issue = result.issues.find(i => i.code === ISSUE_CODES.APPROVAL_WITHOUT_INVOCATION);
+    assert.ok(issue, 'Expected approval_without_invocation issue');
+    assert.strictEqual(issue.context.tool_name, 'merge_pull_request');
+  });
+
+  await test('tool.approval_granted with matching tool.invocation (same tool, same correlation_id) is not flagged', async () => {
+    const result = validate(approvalGrantedSession());
+    const issue = result.issues.find(i => i.code === ISSUE_CODES.APPROVAL_WITHOUT_INVOCATION);
+    assert.strictEqual(issue, undefined);
+  });
+
+  await test('tool.approval_granted with invocation under different correlation_id is flagged', async () => {
+    const events = [
+      evt({ event_id: 'evt-001', event_type: 'tool.approval_granted', action: 'merge_pull_request', correlation_id: 'sess-aaa', metadata: { tool_name: 'merge_pull_request' } }),
+      evt({ event_id: 'evt-002', event_type: 'tool.invocation',       action: 'merge_pull_request', correlation_id: 'sess-bbb', metadata: { tool_name: 'merge_pull_request' } }),
+    ];
+    const result = validate(events);
+    const issue = result.issues.find(i => i.code === ISSUE_CODES.APPROVAL_WITHOUT_INVOCATION);
+    assert.ok(issue, 'Expected approval_without_invocation when correlation_ids differ');
+  });
+
+  // ── 5. Approval evidence for invocations ──────────────────────────────────
+
+  console.log('\n5. Approval evidence — missing_approval_evidence');
+
+  await test('tool.invocation for approval-required tool without approval_granted is flagged', async () => {
+    const events = [
+      evt({ event_id: 'evt-001', event_type: 'session.start',   action: 'mcp_session_init',  metadata: {} }),
+      evt({ event_id: 'evt-002', event_type: 'tool.invocation', action: 'merge_pull_request', metadata: { tool_name: 'merge_pull_request', risk_level: 'HIGH' } }),
+      evt({ event_id: 'evt-003', event_type: 'session.end',     action: 'mcp_session_close',  metadata: {} }),
+    ];
+    const result = validate(events);
+    assert.strictEqual(result.complete, false);
+    const issue = result.issues.find(i => i.code === ISSUE_CODES.MISSING_APPROVAL_EVIDENCE);
+    assert.ok(issue, 'Expected missing_approval_evidence issue');
+    assert.strictEqual(issue.context.tool_name, 'merge_pull_request');
+  });
+
+  await test('tool.invocation for approval-required tool WITH approval_granted is not flagged', async () => {
+    const result = validate(approvalGrantedSession());
+    const issue = result.issues.find(i => i.code === ISSUE_CODES.MISSING_APPROVAL_EVIDENCE);
+    assert.strictEqual(issue, undefined);
+  });
+
+  await test('tool.invocation for LOW tool (get_me) without approval_granted is not flagged', async () => {
+    const result = validate(happyPathSession());
+    const issue = result.issues.find(i => i.code === ISSUE_CODES.MISSING_APPROVAL_EVIDENCE);
+    assert.strictEqual(issue, undefined);
+  });
+
+  await test('tool.invocation for unregistered/unknown tool is not flagged for missing approval', async () => {
+    const events = [
+      evt({ event_id: 'evt-001', event_type: 'session.start',   action: 'mcp_session_init',       metadata: {} }),
+      evt({ event_id: 'evt-002', event_type: 'tool.invocation', action: 'some_unregistered_tool',  metadata: { tool_name: 'some_unregistered_tool' } }),
+      evt({ event_id: 'evt-003', event_type: 'session.end',     action: 'mcp_session_close',       metadata: {} }),
+    ];
+    const result = validate(events);
+    const issue = result.issues.find(i => i.code === ISSUE_CODES.MISSING_APPROVAL_EVIDENCE);
+    assert.strictEqual(issue, undefined);
+  });
+
+  // ── 6. Field integrity ─────────────────────────────────────────────────────
+
+  console.log('\n6. Field integrity — missing_required_field');
+
+  await test('event missing correlation_id is flagged', async () => {
+    const events = [
+      evt({ event_id: 'evt-001', correlation_id: null }),
+    ];
+    const result = validate(events);
+    assert.strictEqual(result.complete, false);
+    const issue = result.issues.find(i =>
+      i.code === ISSUE_CODES.MISSING_REQUIRED_FIELD && i.context.field === 'correlation_id'
+    );
+    assert.ok(issue, 'Expected missing_required_field for correlation_id');
+  });
+
+  await test('event missing event_id is flagged', async () => {
+    const events = [ evt({ event_id: '' }) ];
+    const result = validate(events);
+    const issue = result.issues.find(i =>
+      i.code === ISSUE_CODES.MISSING_REQUIRED_FIELD && i.context.field === 'event_id'
+    );
+    assert.ok(issue, 'Expected missing_required_field for event_id');
+  });
+
+  await test('event with metadata as non-object is flagged', async () => {
+    const events = [ evt({ metadata: 'not-an-object' }) ];
+    const result = validate(events);
+    const issue = result.issues.find(i =>
+      i.code === ISSUE_CODES.MISSING_REQUIRED_FIELD && i.context.field === 'metadata'
+    );
+    assert.ok(issue, 'Expected missing_required_field for non-object metadata');
+  });
+
+  await test('fully valid event has no field integrity issues', async () => {
+    const result = validate([ evt() ]);
+    const fieldIssues = result.issues.filter(i => i.code === ISSUE_CODES.MISSING_REQUIRED_FIELD);
+    assert.strictEqual(fieldIssues.length, 0);
+  });
+
+  // ── 7. Edge cases ─────────────────────────────────────────────────────────
+
+  console.log('\n7. Edge cases');
+
+  await test('non-array input returns complete:false with invalid_input issue', async () => {
+    const result = validate({ not: 'an array' });
+    assert.strictEqual(result.complete, false);
+    assert.ok(result.issues.some(i => i.code === ISSUE_CODES.INVALID_INPUT));
+  });
+
+  await test('null input returns complete:false with invalid_input issue', async () => {
+    const result = validate(null);
+    assert.strictEqual(result.complete, false);
+    assert.ok(result.issues.some(i => i.code === ISSUE_CODES.INVALID_INPUT));
+  });
+
+  await test('ISSUE_CODES are all stable strings', async () => {
+    for (const [key, value] of Object.entries(ISSUE_CODES)) {
+      assert.strictEqual(typeof value, 'string', `Expected ISSUE_CODES.${key} to be a string`);
+      assert.ok(value.length > 0, `Expected ISSUE_CODES.${key} to be non-empty`);
+    }
+  });
+
+  await test('all expected ISSUE_CODES are present', async () => {
+    const expected = [
+      'INVALID_INPUT',
+      'MISSING_REQUIRED_FIELD',
+      'MISSING_SESSION_START',
+      'MISSING_SESSION_END',
+      'INCONSISTENT_SESSION_CORRELATION',
+      'APPROVAL_WITHOUT_INVOCATION',
+      'MISSING_APPROVAL_EVIDENCE',
+    ];
+    for (const key of expected) {
+      assert.ok(key in ISSUE_CODES, `Expected ISSUE_CODES.${key} to exist`);
+    }
+  });
+
+  await test('secret.retrieval is treated as session-activity (triggers missing_session_start)', async () => {
+    const events = [
+      evt({ event_id: 'evt-001', event_type: 'secret.retrieval', action: 'keeper-commander', metadata: { secret_identifier: 'some/secret', retrieval_mechanism: 'keeper-commander', retrieval_mode: 'non-interactive', environment_context: 'service' } }),
+    ];
+    const result = validate(events);
+    const codes = result.issues.map(i => i.code);
+    assert.ok(codes.includes(ISSUE_CODES.MISSING_SESSION_START));
+  });
+
+  // ── 8. Individual rule exports ────────────────────────────────────────────
+
+  console.log('\n8. Individual rule exports — callable and return correct shape');
+
+  await test('checkRequiredFields returns { issues, warnings }', async () => {
+    const result = checkRequiredFields([evt()]);
+    assert.ok(Array.isArray(result.issues));
+    assert.ok(Array.isArray(result.warnings));
+  });
+
+  await test('checkSessionCoverage returns { issues, warnings }', async () => {
+    const result = checkSessionCoverage([]);
+    assert.ok(Array.isArray(result.issues));
+    assert.ok(Array.isArray(result.warnings));
+  });
+
+  await test('checkCorrelationConsistency returns { issues, warnings }', async () => {
+    const result = checkCorrelationConsistency([]);
+    assert.ok(Array.isArray(result.issues));
+    assert.ok(Array.isArray(result.warnings));
+  });
+
+  await test('checkApprovalPathCompleteness returns { issues, warnings }', async () => {
+    const result = checkApprovalPathCompleteness([]);
+    assert.ok(Array.isArray(result.issues));
+    assert.ok(Array.isArray(result.warnings));
+  });
+
+  await test('checkApprovalEvidenceForInvocations returns { issues, warnings }', async () => {
+    const result = checkApprovalEvidenceForInvocations([]);
+    assert.ok(Array.isArray(result.issues));
+    assert.ok(Array.isArray(result.warnings));
+  });
+
+  // ── Summary ───────────────────────────────────────────────────────────────
+
+  const bar = '─'.repeat(40);
+  console.log(`\n${bar}`);
+  console.log(`Results: ${passed} passed, ${failed} failed`);
+  if (failed > 0) process.exit(1);
+
+})().catch(err => {
+  console.error('\nValidation script crashed:', err.message);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- Introduces `src/detection/event-completeness-validator.js` — a pure validator that accepts a sequence of audit events and returns a structured completeness result
- Defines five explicit completeness rules: field integrity, session coverage, correlation consistency, approval path completeness, and approval evidence for invocations
- Exports stable `ISSUE_CODES` constants for downstream consumer use
- 33 tests covering all rule paths, edge cases, and regression against prior controls

## Changes

- `src/detection/event-completeness-validator.js` — validator module with five rules; `validate()` entry point; exported rule functions for targeted testing; `ISSUE_CODES` constants
- `tests/validate-event-completeness.js` — 33 tests across 8 test groups
- `docs/detection/event-completeness-validation.md` — full documentation: what is checked, what is not, rules table, result shape, issue codes, relationship to platform controls, future extension points

## Test plan

- [x] `node tests/validate-event-completeness.js` — 33 passed, 0 failed
- [x] `node tests/validate-policy-gate.js` — 21 passed, 0 failed (regression)
- [x] `node tests/validate-approval-gate.js` — 24 passed, 0 failed (regression)

Implements: CC-HMCP-000012 / TD-HMCP-000003

🤖 Generated with [Claude Code](https://claude.com/claude-code)