### PR TITLE
feat: implement correlation integrity validation (TD-HMCP-000004)

### DIFF
--- a/docs/detection/correlation-integrity-checks.md
+++ b/docs/detection/correlation-integrity-checks.md
@@ -1,0 +1,195 @@
+# Correlation Integrity Checks — TD-HMCP-000004
+
+## Purpose
+
+The correlation integrity validator examines a sequence of audit events and determines whether correlation linkage is internally consistent — that is, whether events that should be bound together through `correlation_id` actually are.
+
+Correlation integrity answers the question:
+
+> "Are the events in this trace correctly linked to each other, or has the correlation context been broken, mixed, or lost?"
+
+A trace can be structurally complete (all required event types present) but correlation-invalid (those events cannot be reliably tied together). Both dimensions are needed before a trace can be treated as trustworthy audit evidence.
+
+---
+
+## Relationship to Event Completeness Validation
+
+These are two distinct, complementary validators:
+
+| Validator | Checks | Result Field |
+|---|---|---|
+| `event-completeness-validator` | Are the expected event types present? (session.start, session.end, approval evidence, required fields) | `complete: boolean` |
+| `correlation-integrity-validator` (this) | Are the events that exist correctly linked through correlation_id? | `valid: boolean` |
+
+A trace can fail one without failing the other:
+
+- **Complete but integrity-invalid:** all required events present, but a denial event has a different `correlation_id` than the session — the events can't be reliably linked.
+- **Integrity-valid but incomplete:** consistent `correlation_id` throughout, but `session.end` is missing — the session was not properly closed.
+
+Both validators should be run together for full audit trust. A higher-level audit validation layer can compose both results.
+
+---
+
+## What Correlation Integrity Checks
+
+Four rules are evaluated:
+
+### Rule 1 — Correlation Presence
+
+Every event must carry a non-empty `correlation_id`. An event without one cannot be attributed to any session or execution path and is not trustworthy as audit evidence.
+
+Issue code: `missing_correlation_id`
+
+---
+
+### Rule 2 — Session Activity Alignment
+
+When a trace contains exactly one `session.start` event, all session-activity events (`tool.invocation`, `tool.denial`, `tool.approval_granted`, `secret.retrieval`) must share the same `correlation_id` as that `session.start`.
+
+An activity event with a different `correlation_id` cannot be attributed to the session — it is either from a different session or is orphaned.
+
+Scope: applies only when the trace has exactly one `session.start`. Traces with zero or multiple `session.start` events are outside the scope of this rule (handled by other rules or by multi-session decomposition, which is a deferred capability).
+
+Issue code: `inconsistent_correlation_id`
+
+---
+
+### Rule 3 — Trace Context Consistency
+
+A trace is expected to represent a single correlation context (one session). If the number of distinct `correlation_id` values in the trace exceeds the number of `session.start` events, events from incompatible contexts have been mixed into the same trace.
+
+Formula: `distinct_correlation_ids > session_start_count` → conflicting context.
+
+Two `session.start` events with two distinct `correlation_id`s is not flagged — that represents a valid two-session trace. One `session.start` with two distinct IDs is flagged.
+
+Issue code: `conflicting_trace_context`
+
+---
+
+### Rule 4 — Unlinked Control Events
+
+A `tool.denial` or `tool.approval_granted` event is "unlinked" when its `correlation_id` is not shared by any other event in the trace, and the trace contains more than one event.
+
+An unlinked control event cannot be attributed to any execution path. This indicates either that the event was captured in the wrong trace, or that the other events in its execution path were not captured.
+
+Single-event traces are exempt: a lone denial or approval event with a valid `correlation_id` is a valid isolated audit record.
+
+Issue codes: `unlinked_denial_event`, `unlinked_approval_event`
+
+---
+
+## What Correlation Integrity Is NOT Checking
+
+This validator does not:
+
+- **Check event type presence** — it does not verify that `session.start`, `session.end`, or approval events exist. That is the completeness validator's responsibility.
+- **Validate timestamp ordering** — events are not checked for chronological consistency within a session.
+- **Detect behavioral anomalies** — it does not flag unusual correlation patterns or access sequences. That is future work.
+- **Handle multi-session traces** — the validator is designed for single-session traces. Multi-session grouping by `correlation_id` is a deferred capability.
+- **Check correlation_id format** — it checks for presence and consistency, not adherence to a specific format (e.g., UUID, prefix pattern).
+
+---
+
+## Validation Rules Summary
+
+| Rule | Issue Code | Trigger Condition |
+|---|---|---|
+| Correlation presence | `missing_correlation_id` | Event has null or empty `correlation_id` |
+| Session activity alignment | `inconsistent_correlation_id` | Activity event's `correlation_id` differs from `session.start`'s (single-session trace) |
+| Trace context consistency | `conflicting_trace_context` | Distinct `correlation_id` count exceeds `session.start` count |
+| Unlinked control events | `unlinked_denial_event` | `tool.denial` CID not shared by any other event (multi-event trace) |
+| Unlinked control events | `unlinked_approval_event` | `tool.approval_granted` CID not shared by any other event (multi-event trace) |
+| Invalid input | `invalid_input` | Input is not an array |
+
+---
+
+## Validator Result Shape
+
+```js
+const { validate } = require('./src/detection/correlation-integrity-validator');
+const result = validate(events);
+```
+
+```json
+{
+  "valid": false,
+  "issues": [
+    {
+      "code": "inconsistent_correlation_id",
+      "message": "Event correlation_id \"sess-bbb\" does not match session correlation_id \"sess-aaa\"",
+      "context": {
+        "event_id": "evt-002",
+        "event_type": "tool.denial",
+        "tool_name": "delete_branch",
+        "event_correlation_id": "sess-bbb",
+        "session_correlation_id": "sess-aaa"
+      }
+    }
+  ],
+  "warnings": []
+}
+```
+
+- `valid: true` — no issues found; correlation linkage is trustworthy
+- `valid: false` — one or more issues found; correlation linkage cannot be trusted
+- `issues` — integrity failures; each has a stable `code`, human-readable `message`, and optional `context`
+- `warnings` — advisory findings (reserved; currently empty)
+
+---
+
+## Stable Issue Codes
+
+```js
+const { ISSUE_CODES } = require('./src/detection/correlation-integrity-validator');
+// ISSUE_CODES.MISSING_CORRELATION_ID === 'missing_correlation_id'
+```
+
+| Constant | Code |
+|---|---|
+| `INVALID_INPUT` | `invalid_input` |
+| `MISSING_CORRELATION_ID` | `missing_correlation_id` |
+| `INCONSISTENT_CORRELATION_ID` | `inconsistent_correlation_id` |
+| `CONFLICTING_TRACE_CONTEXT` | `conflicting_trace_context` |
+| `UNLINKED_DENIAL_EVENT` | `unlinked_denial_event` |
+| `UNLINKED_APPROVAL_EVENT` | `unlinked_approval_event` |
+
+---
+
+## How This Supports Future Work
+
+### Combined Audit Validation
+
+A higher-level `validateTrace(events)` function could run both the completeness and integrity validators, combining their issues into a single audit trust result. The two validators are designed to compose cleanly — they share the same `{ issues, warnings }` rule return structure and stable `ISSUE_CODES` patterns.
+
+### Sequence Validation
+
+Rule 2 (session activity alignment) and Rule 4 (unlinked control events) establish the correlation linkage required for future sequence-based checks. Once correlation is trusted, validators can begin reasoning about event ordering (e.g., "approval must precede invocation") without first having to solve the attribution problem.
+
+### Anomaly Detection
+
+Correlation integrity is a prerequisite for anomaly detection. An anomaly detector needs to group events by session before identifying unusual patterns. The correlation integrity validator provides the assurance that the grouping is valid.
+
+### Multi-Session Grouping
+
+Rule 3 (trace context consistency) is designed to flag single-session traces that contain multiple correlation contexts. A future multi-session trace decomposer could split such traces by `correlation_id`, run each sub-trace through the validators independently, and aggregate results.
+
+---
+
+## Relationship to Platform Controls
+
+| Component | Role |
+|---|---|
+| `CTRL-HMCP-000002` | Produces `tool.denial` events; denial correlation integrity validated by Rules 2 and 4 |
+| `CTRL-HMCP-000003` | Produces `tool.approval_granted` events; approval correlation integrity validated by Rules 2 and 4 |
+| `TD-HMCP-000003` (completeness) | Validates event presence; complements this validator |
+| `TD-HMCP-000004` (this) | Validates correlation linkage; complements completeness validation |
+
+---
+
+## Module Location
+
+```
+src/detection/correlation-integrity-validator.js
+```
+
+Tests: `tests/validate-correlation-integrity.js`

--- a/src/detection/correlation-integrity-validator.js
+++ b/src/detection/correlation-integrity-validator.js
@@ -1,0 +1,322 @@
+/**
+ * Home MCP Compliance Lab — Correlation Integrity Validator (TD-HMCP-000004)
+ *
+ * Validates whether correlation linkage is internally consistent across the
+ * events in a trace. A trace is correlation-valid when all events that should
+ * be bound together are correctly linked through their correlation_id fields.
+ *
+ * Relationship to event-completeness-validator:
+ *   Completeness  — are the expected event types present? (e.g., session.start,
+ *                   session.end, approval evidence)
+ *   Integrity     — are the events that exist correctly linked to each other?
+ *   Both validators are independent. A trace can be complete but integrity-
+ *   invalid (e.g., all required events present but with mismatched IDs), or
+ *   integrity-valid but incomplete (e.g., correct IDs throughout but session.end
+ *   missing). A higher-level audit validation layer can compose both.
+ *
+ * Rules evaluated:
+ *   1. Correlation presence       — every event carries a non-empty correlation_id
+ *   2. Session activity alignment — session-activity events match the session.start
+ *                                   correlation_id (when exactly one session.start
+ *                                   is in the trace)
+ *   3. Trace context consistency  — trace should not mix events from incompatible
+ *                                   correlation contexts (more distinct IDs than
+ *                                   session boundaries)
+ *   4. Unlinked control events    — tool.denial / tool.approval_granted events
+ *                                   whose correlation_id is shared by no other
+ *                                   event in a multi-event trace
+ *
+ * Pure module — no file I/O, no external calls, no side effects.
+ *
+ * Usage:
+ *   const { validate } = require('./correlation-integrity-validator');
+ *   const result = validate(events);
+ *   // { valid: boolean, issues: Array<Issue>, warnings: Array<Warning> }
+ *
+ * Result shape:
+ *   {
+ *     valid:     boolean   — true only when issues is empty
+ *     issues:    Issue[]   — integrity failures; linkage cannot be trusted
+ *     warnings:  Warning[] — advisory findings (reserved; currently empty)
+ *   }
+ *
+ * Issue shape:
+ *   {
+ *     code:     string   — stable machine-readable code (see ISSUE_CODES)
+ *     message:  string   — human-readable description
+ *     context:  object   — optional — event_id, correlation_id, tool_name, etc.
+ *   }
+ */
+
+'use strict';
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+/**
+ * Stable issue codes for correlation integrity failures.
+ */
+const ISSUE_CODES = {
+  INVALID_INPUT:               'invalid_input',
+  MISSING_CORRELATION_ID:      'missing_correlation_id',
+  INCONSISTENT_CORRELATION_ID: 'inconsistent_correlation_id',
+  CONFLICTING_TRACE_CONTEXT:   'conflicting_trace_context',
+  UNLINKED_DENIAL_EVENT:       'unlinked_denial_event',
+  UNLINKED_APPROVAL_EVENT:     'unlinked_approval_event',
+};
+
+// Event types that are session-scoped; expected to share the session correlation_id.
+const SESSION_ACTIVITY_TYPES = new Set([
+  'tool.invocation',
+  'tool.denial',
+  'tool.approval_granted',
+  'secret.retrieval',
+]);
+
+// Control event types that should always be linkable to a broader execution path.
+const CONTROL_EVENT_TYPES = {
+  DENIAL:   'tool.denial',
+  APPROVAL: 'tool.approval_granted',
+};
+
+// ── Issue / warning factories ─────────────────────────────────────────────────
+
+function mkIssue(code, message, context) {
+  const result = { code, message };
+  if (context != null) result.context = context;
+  return result;
+}
+
+// Reserved for future advisory findings.
+// eslint-disable-next-line no-unused-vars
+function mkWarning(code, message, context) {
+  const result = { code, message };
+  if (context != null) result.context = context;
+  return result;
+}
+
+// ── Helper ────────────────────────────────────────────────────────────────────
+
+function toolNameOf(event) {
+  return (event.metadata && event.metadata.tool_name) || event.action || null;
+}
+
+// ── Rules ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Rule 1 — Correlation Presence
+ *
+ * Every event in the trace must carry a non-empty correlation_id. An event
+ * without a correlation_id cannot be attributed to any session or execution
+ * path and is untrustworthy as audit evidence.
+ *
+ * Issues: missing_correlation_id
+ */
+function checkCorrelationPresence(events) {
+  const issues = [];
+
+  for (const evt of events) {
+    const cid = evt.correlation_id;
+    if (cid == null || cid === '') {
+      issues.push(mkIssue(
+        ISSUE_CODES.MISSING_CORRELATION_ID,
+        'Event is missing a correlation_id',
+        {
+          event_id:   evt.event_id   || '(unknown)',
+          event_type: evt.event_type || '(unknown)',
+        }
+      ));
+    }
+  }
+
+  return { issues, warnings: [] };
+}
+
+/**
+ * Rule 2 — Session Activity Alignment
+ *
+ * When the trace contains exactly one session.start event, all session-activity
+ * events (tool.invocation, tool.denial, tool.approval_granted, secret.retrieval)
+ * must share the same correlation_id as that session.start.
+ *
+ * An activity event with a different correlation_id cannot be reliably attributed
+ * to the session and is likely from a different session or is orphaned.
+ *
+ * Scope: applies only when there is exactly one session.start in the trace.
+ * When there are zero or multiple session.start events, this rule is skipped
+ * (handled by other rules or out of scope for single-session validation).
+ *
+ * Issues: inconsistent_correlation_id
+ */
+function checkSessionActivityAlignment(events) {
+  const issues = [];
+
+  const sessionStarts = events.filter(e => e.event_type === 'session.start');
+  if (sessionStarts.length !== 1) return { issues, warnings: [] };
+
+  const sessionCid = sessionStarts[0].correlation_id;
+  if (!sessionCid) return { issues, warnings: [] };
+
+  const activityEvents = events.filter(e => SESSION_ACTIVITY_TYPES.has(e.event_type));
+
+  for (const evt of activityEvents) {
+    const evtCid = evt.correlation_id;
+    if (evtCid && evtCid !== sessionCid) {
+      issues.push(mkIssue(
+        ISSUE_CODES.INCONSISTENT_CORRELATION_ID,
+        `Event correlation_id "${evtCid}" does not match session correlation_id "${sessionCid}"`,
+        {
+          event_id:            evt.event_id   || '(unknown)',
+          event_type:          evt.event_type || '(unknown)',
+          tool_name:           toolNameOf(evt),
+          event_correlation_id:   evtCid,
+          session_correlation_id: sessionCid,
+        }
+      ));
+    }
+  }
+
+  return { issues, warnings: [] };
+}
+
+/**
+ * Rule 3 — Trace Context Consistency
+ *
+ * A trace is expected to represent a single correlation context (one session).
+ * If the number of distinct correlation_ids in the trace exceeds the number of
+ * session.start events, events from incompatible contexts have been mixed into
+ * the same trace. This indicates corrupted trace assembly or orphaned events.
+ *
+ * Formula: distinct_correlation_ids > session_start_count → conflicting context.
+ * Null/empty correlation_ids are excluded from the distinct-ID count (already
+ * caught by Rule 1).
+ *
+ * Issues: conflicting_trace_context
+ */
+function checkTraceContextConsistency(events) {
+  const issues = [];
+
+  const allCids    = events.map(e => e.correlation_id).filter(c => c != null && c !== '');
+  const distinctCids  = new Set(allCids);
+  const sessionStartCount = events.filter(e => e.event_type === 'session.start').length;
+
+  if (distinctCids.size > sessionStartCount && distinctCids.size > 1) {
+    issues.push(mkIssue(
+      ISSUE_CODES.CONFLICTING_TRACE_CONTEXT,
+      `Trace contains ${distinctCids.size} distinct correlation_id(s) but only ${sessionStartCount} session.start event(s); events from incompatible contexts may be mixed`,
+      {
+        distinct_correlation_id_count: distinctCids.size,
+        session_start_count:           sessionStartCount,
+        correlation_ids:               Array.from(distinctCids),
+      }
+    ));
+  }
+
+  return { issues, warnings: [] };
+}
+
+/**
+ * Rule 4 — Unlinked Control Events
+ *
+ * A tool.denial or tool.approval_granted event is "unlinked" when its
+ * correlation_id does not appear in any other event in the trace, and the
+ * trace contains more than one event total. An unlinked control event cannot
+ * be attributed to any session or execution path.
+ *
+ * Single-event traces are exempt: a lone control event with a valid
+ * correlation_id is a valid isolated audit record.
+ *
+ * Issues: unlinked_denial_event, unlinked_approval_event
+ */
+function checkUnlinkedControlEvents(events) {
+  const issues = [];
+
+  if (events.length <= 1) return { issues, warnings: [] };
+
+  for (const evt of events) {
+    const isDenial   = evt.event_type === CONTROL_EVENT_TYPES.DENIAL;
+    const isApproval = evt.event_type === CONTROL_EVENT_TYPES.APPROVAL;
+    if (!isDenial && !isApproval) continue;
+
+    const cid = evt.correlation_id;
+    if (!cid) continue; // Already caught by Rule 1.
+
+    // Is this CID shared by any other event in the trace?
+    const isLinked = events.some(other => other !== evt && other.correlation_id === cid);
+
+    if (!isLinked) {
+      const code = isDenial
+        ? ISSUE_CODES.UNLINKED_DENIAL_EVENT
+        : ISSUE_CODES.UNLINKED_APPROVAL_EVENT;
+
+      const label = isDenial ? 'tool.denial' : 'tool.approval_granted';
+
+      issues.push(mkIssue(
+        code,
+        `${label} event has a correlation_id ("${cid}") not shared by any other event in the trace`,
+        {
+          event_id:       evt.event_id   || '(unknown)',
+          tool_name:      toolNameOf(evt),
+          correlation_id: cid,
+        }
+      ));
+    }
+  }
+
+  return { issues, warnings: [] };
+}
+
+// ── Registered ruleset ────────────────────────────────────────────────────────
+
+const RULES = [
+  checkCorrelationPresence,
+  checkSessionActivityAlignment,
+  checkTraceContextConsistency,
+  checkUnlinkedControlEvents,
+];
+
+// ── Validator ─────────────────────────────────────────────────────────────────
+
+/**
+ * Validate a sequence of audit events for correlation integrity.
+ *
+ * @param {object[]} events — array of audit event objects
+ * @returns {{ valid: boolean, issues: object[], warnings: object[] }}
+ */
+function validate(events) {
+  if (!Array.isArray(events)) {
+    return {
+      valid: false,
+      issues: [mkIssue(
+        ISSUE_CODES.INVALID_INPUT,
+        'events must be an array',
+        { received: typeof events }
+      )],
+      warnings: [],
+    };
+  }
+
+  const allIssues   = [];
+  const allWarnings = [];
+
+  for (const rule of RULES) {
+    const { issues, warnings } = rule(events);
+    allIssues.push(...issues);
+    allWarnings.push(...warnings);
+  }
+
+  return {
+    valid:    allIssues.length === 0,
+    issues:   allIssues,
+    warnings: allWarnings,
+  };
+}
+
+module.exports = {
+  validate,
+  ISSUE_CODES,
+  // Export individual rules for targeted unit testing.
+  checkCorrelationPresence,
+  checkSessionActivityAlignment,
+  checkTraceContextConsistency,
+  checkUnlinkedControlEvents,
+};

--- a/tests/validate-correlation-integrity.js
+++ b/tests/validate-correlation-integrity.js
@@ -1,0 +1,467 @@
+'use strict';
+
+// Validation tests for TD-HMCP-000004 — Correlation Integrity Checks
+//
+// Validates:
+//   1. Valid correlated traces pass
+//   2. Missing correlation_id is flagged (Rule 1)
+//   3. Activity events misaligned with session correlation are flagged (Rule 2)
+//   4. Conflicting trace context (mixed correlation scopes) is flagged (Rule 3)
+//   5. Unlinked denial/approval events are flagged (Rule 4)
+//   6. Malformed inputs handled cleanly
+//   7. Current event flows (completeness fixtures) continue to pass
+//
+// No network required. Run: node tests/validate-correlation-integrity.js
+
+const assert = require('assert');
+
+let passed = 0;
+let failed = 0;
+
+async function test(name, fn) {
+  try {
+    await fn();
+    console.log(`  [PASS] ${name}`);
+    passed++;
+  } catch (err) {
+    console.error(`  [FAIL] ${name}: ${err.message}`);
+    failed++;
+  }
+}
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const CID_A = 'sess-20260407-aaa';
+const CID_B = 'sess-20260407-bbb';
+
+function evt(overrides) {
+  return {
+    event_id:       `evt-${Math.random().toString(36).slice(2, 9)}`,
+    event_type:     'tool.invocation',
+    timestamp:      '2026-04-07T12:00:00Z',
+    platform:       'home-mcp-lab',
+    project_id:     'home-mcp-lab',
+    agent_id:       'test-agent',
+    mcp_server:     'github-mcp-server',
+    action:         'get_me',
+    status:         'success',
+    correlation_id: CID_A,
+    metadata:       { tool_name: 'get_me' },
+    ...overrides,
+  };
+}
+
+// Full clean session: start → invocation → end, all same CID.
+function cleanSession(cid) {
+  const c = cid || CID_A;
+  return [
+    evt({ event_id: 'e-001', event_type: 'session.start',  action: 'mcp_session_init',  correlation_id: c, metadata: {} }),
+    evt({ event_id: 'e-002', event_type: 'tool.invocation', action: 'get_me',            correlation_id: c, metadata: { tool_name: 'get_me' } }),
+    evt({ event_id: 'e-003', event_type: 'session.end',    action: 'mcp_session_close',  correlation_id: c, metadata: {} }),
+  ];
+}
+
+// Approval path: start → approval_granted → invocation → end, all same CID.
+function approvalSession() {
+  return [
+    evt({ event_id: 'e-001', event_type: 'session.start',         action: 'mcp_session_init',  correlation_id: CID_A, metadata: {} }),
+    evt({ event_id: 'e-002', event_type: 'tool.approval_granted', action: 'merge_pull_request', correlation_id: CID_A, metadata: { tool_name: 'merge_pull_request' } }),
+    evt({ event_id: 'e-003', event_type: 'tool.invocation',       action: 'merge_pull_request', correlation_id: CID_A, metadata: { tool_name: 'merge_pull_request' } }),
+    evt({ event_id: 'e-004', event_type: 'session.end',           action: 'mcp_session_close',  correlation_id: CID_A, metadata: {} }),
+  ];
+}
+
+// Denial path: start → denial → end, all same CID.
+function denialSession() {
+  return [
+    evt({ event_id: 'e-001', event_type: 'session.start', action: 'mcp_session_init',  correlation_id: CID_A, metadata: {} }),
+    evt({ event_id: 'e-002', event_type: 'tool.denial',   action: 'delete_branch',     correlation_id: CID_A, status: 'failure', metadata: { tool_name: 'delete_branch' } }),
+    evt({ event_id: 'e-003', event_type: 'session.end',   action: 'mcp_session_close', correlation_id: CID_A, metadata: {} }),
+  ];
+}
+
+// ── Load validator ────────────────────────────────────────────────────────────
+
+const {
+  validate,
+  ISSUE_CODES,
+  checkCorrelationPresence,
+  checkSessionActivityAlignment,
+  checkTraceContextConsistency,
+  checkUnlinkedControlEvents,
+} = require('../src/detection/correlation-integrity-validator');
+
+// ── 1. Valid traces pass ──────────────────────────────────────────────────────
+
+(async () => {
+
+  console.log('\n1. Valid traces — recognized as correlation-valid');
+
+  await test('clean session (start → invocation → end, uniform CID) is valid', async () => {
+    const result = validate(cleanSession());
+    assert.strictEqual(result.valid, true, `Issues: ${JSON.stringify(result.issues)}`);
+    assert.strictEqual(result.issues.length, 0);
+  });
+
+  await test('approval path session (uniform CID) is valid', async () => {
+    const result = validate(approvalSession());
+    assert.strictEqual(result.valid, true, `Issues: ${JSON.stringify(result.issues)}`);
+    assert.strictEqual(result.issues.length, 0);
+  });
+
+  await test('denial path session (uniform CID) is valid', async () => {
+    const result = validate(denialSession());
+    assert.strictEqual(result.valid, true, `Issues: ${JSON.stringify(result.issues)}`);
+    assert.strictEqual(result.issues.length, 0);
+  });
+
+  await test('empty trace is valid', async () => {
+    const result = validate([]);
+    assert.strictEqual(result.valid, true);
+    assert.strictEqual(result.issues.length, 0);
+  });
+
+  await test('single session.start-only event is valid', async () => {
+    const result = validate([
+      evt({ event_type: 'session.start', correlation_id: CID_A, action: 'mcp_session_init', metadata: {} }),
+    ]);
+    assert.strictEqual(result.valid, true);
+  });
+
+  await test('result always has valid, issues, and warnings fields', async () => {
+    const result = validate([]);
+    assert.ok('valid'    in result);
+    assert.ok(Array.isArray(result.issues));
+    assert.ok(Array.isArray(result.warnings));
+  });
+
+  // ── 2. Rule 1 — Correlation presence ─────────────────────────────────────
+
+  console.log('\n2. Rule 1 — missing_correlation_id');
+
+  await test('event with null correlation_id is flagged', async () => {
+    const result = validate([ evt({ correlation_id: null }) ]);
+    assert.strictEqual(result.valid, false);
+    const issue = result.issues.find(i => i.code === ISSUE_CODES.MISSING_CORRELATION_ID);
+    assert.ok(issue, 'Expected missing_correlation_id issue');
+  });
+
+  await test('event with empty-string correlation_id is flagged', async () => {
+    const result = validate([ evt({ correlation_id: '' }) ]);
+    assert.strictEqual(result.valid, false);
+    const issue = result.issues.find(i => i.code === ISSUE_CODES.MISSING_CORRELATION_ID);
+    assert.ok(issue, 'Expected missing_correlation_id issue');
+  });
+
+  await test('issue context includes event_id and event_type', async () => {
+    const events = [ evt({ event_id: 'e-xyz', event_type: 'tool.invocation', correlation_id: null }) ];
+    const result = validate(events);
+    const issue = result.issues.find(i => i.code === ISSUE_CODES.MISSING_CORRELATION_ID);
+    assert.ok(issue);
+    assert.strictEqual(issue.context.event_id, 'e-xyz');
+    assert.strictEqual(issue.context.event_type, 'tool.invocation');
+  });
+
+  await test('multiple events with missing correlation_ids each produce an issue', async () => {
+    const events = [
+      evt({ event_id: 'e-001', correlation_id: null }),
+      evt({ event_id: 'e-002', correlation_id: null }),
+    ];
+    const result = validate(events);
+    const missing = result.issues.filter(i => i.code === ISSUE_CODES.MISSING_CORRELATION_ID);
+    assert.strictEqual(missing.length, 2);
+  });
+
+  await test('event with valid correlation_id is not flagged', async () => {
+    const result = validate([ evt({ correlation_id: CID_A }) ]);
+    const issue = result.issues.find(i => i.code === ISSUE_CODES.MISSING_CORRELATION_ID);
+    assert.strictEqual(issue, undefined);
+  });
+
+  // ── 3. Rule 2 — Session activity alignment ────────────────────────────────
+
+  console.log('\n3. Rule 2 — inconsistent_correlation_id');
+
+  await test('activity event with different CID from session.start is flagged', async () => {
+    const events = [
+      evt({ event_id: 'e-001', event_type: 'session.start',   correlation_id: CID_A, action: 'mcp_session_init', metadata: {} }),
+      evt({ event_id: 'e-002', event_type: 'tool.invocation', correlation_id: CID_B, action: 'get_me',           metadata: { tool_name: 'get_me' } }),
+      evt({ event_id: 'e-003', event_type: 'session.end',     correlation_id: CID_A, action: 'mcp_session_close', metadata: {} }),
+    ];
+    const result = validate(events);
+    assert.strictEqual(result.valid, false);
+    const issue = result.issues.find(i => i.code === ISSUE_CODES.INCONSISTENT_CORRELATION_ID);
+    assert.ok(issue, 'Expected inconsistent_correlation_id issue');
+    assert.strictEqual(issue.context.event_correlation_id,   CID_B);
+    assert.strictEqual(issue.context.session_correlation_id, CID_A);
+  });
+
+  await test('denial event with different CID from session.start is flagged', async () => {
+    const events = [
+      evt({ event_id: 'e-001', event_type: 'session.start', correlation_id: CID_A, action: 'mcp_session_init', metadata: {} }),
+      evt({ event_id: 'e-002', event_type: 'tool.denial',   correlation_id: CID_B, action: 'delete_branch',    status: 'failure', metadata: { tool_name: 'delete_branch' } }),
+      evt({ event_id: 'e-003', event_type: 'session.end',   correlation_id: CID_A, action: 'mcp_session_close', metadata: {} }),
+    ];
+    const result = validate(events);
+    const issue = result.issues.find(i => i.code === ISSUE_CODES.INCONSISTENT_CORRELATION_ID);
+    assert.ok(issue, 'Expected inconsistent_correlation_id for misaligned denial');
+    assert.strictEqual(issue.context.event_type, 'tool.denial');
+  });
+
+  await test('approval event with different CID from session.start is flagged', async () => {
+    const events = [
+      evt({ event_id: 'e-001', event_type: 'session.start',         correlation_id: CID_A, action: 'mcp_session_init',  metadata: {} }),
+      evt({ event_id: 'e-002', event_type: 'tool.approval_granted', correlation_id: CID_B, action: 'merge_pull_request', metadata: { tool_name: 'merge_pull_request' } }),
+      evt({ event_id: 'e-003', event_type: 'tool.invocation',       correlation_id: CID_A, action: 'merge_pull_request', metadata: { tool_name: 'merge_pull_request' } }),
+      evt({ event_id: 'e-004', event_type: 'session.end',           correlation_id: CID_A, action: 'mcp_session_close',  metadata: {} }),
+    ];
+    const result = validate(events);
+    const issue = result.issues.find(i => i.code === ISSUE_CODES.INCONSISTENT_CORRELATION_ID);
+    assert.ok(issue, 'Expected inconsistent_correlation_id for misaligned approval');
+    assert.strictEqual(issue.context.event_type, 'tool.approval_granted');
+  });
+
+  await test('rule 2 skipped when zero session.start events in trace', async () => {
+    // No session.start → Rule 2 does not apply; no inconsistency flagged by this rule.
+    const events = [
+      evt({ event_id: 'e-001', event_type: 'tool.invocation', correlation_id: CID_A, metadata: { tool_name: 'get_me' } }),
+      evt({ event_id: 'e-002', event_type: 'tool.invocation', correlation_id: CID_B, metadata: { tool_name: 'get_me' } }),
+    ];
+    const result = checkSessionActivityAlignment(events);
+    assert.strictEqual(result.issues.length, 0, 'Rule 2 should not fire with no session.start');
+  });
+
+  await test('rule 2 skipped when multiple session.start events in trace', async () => {
+    // Two session.starts → multi-session trace; Rule 2 is scoped to single-session only.
+    const events = [
+      evt({ event_id: 'e-001', event_type: 'session.start',   correlation_id: CID_A, action: 'mcp_session_init', metadata: {} }),
+      evt({ event_id: 'e-002', event_type: 'session.start',   correlation_id: CID_B, action: 'mcp_session_init', metadata: {} }),
+      evt({ event_id: 'e-003', event_type: 'tool.invocation', correlation_id: CID_B, metadata: { tool_name: 'get_me' } }),
+    ];
+    const result = checkSessionActivityAlignment(events);
+    assert.strictEqual(result.issues.length, 0, 'Rule 2 should not fire with multiple session.starts');
+  });
+
+  await test('secret.retrieval with mismatched CID is flagged by rule 2', async () => {
+    const events = [
+      evt({ event_id: 'e-001', event_type: 'session.start',    correlation_id: CID_A, action: 'mcp_session_init', metadata: {} }),
+      evt({ event_id: 'e-002', event_type: 'secret.retrieval', correlation_id: CID_B, action: 'keeper-commander', metadata: { secret_identifier: 'some/secret', retrieval_mechanism: 'keeper-commander', retrieval_mode: 'non-interactive', environment_context: 'service' } }),
+    ];
+    const result = validate(events);
+    const issue = result.issues.find(i => i.code === ISSUE_CODES.INCONSISTENT_CORRELATION_ID);
+    assert.ok(issue, 'Expected inconsistent_correlation_id for misaligned secret.retrieval');
+  });
+
+  // ── 4. Rule 3 — Trace context consistency ────────────────────────────────
+
+  console.log('\n4. Rule 3 — conflicting_trace_context');
+
+  await test('trace with two distinct CIDs and one session.start is flagged', async () => {
+    const events = [
+      evt({ event_id: 'e-001', event_type: 'session.start',   correlation_id: CID_A, action: 'mcp_session_init', metadata: {} }),
+      evt({ event_id: 'e-002', event_type: 'tool.invocation', correlation_id: CID_A, metadata: { tool_name: 'get_me' } }),
+      evt({ event_id: 'e-003', event_type: 'tool.invocation', correlation_id: CID_B, metadata: { tool_name: 'get_me' } }),
+    ];
+    const result = validate(events);
+    assert.strictEqual(result.valid, false);
+    const issue = result.issues.find(i => i.code === ISSUE_CODES.CONFLICTING_TRACE_CONTEXT);
+    assert.ok(issue, 'Expected conflicting_trace_context');
+    assert.strictEqual(issue.context.distinct_correlation_id_count, 2);
+    assert.strictEqual(issue.context.session_start_count, 1);
+  });
+
+  await test('trace with two distinct CIDs and no session.start is flagged', async () => {
+    const events = [
+      evt({ event_id: 'e-001', event_type: 'tool.invocation', correlation_id: CID_A, metadata: { tool_name: 'get_me' } }),
+      evt({ event_id: 'e-002', event_type: 'tool.invocation', correlation_id: CID_B, metadata: { tool_name: 'get_me' } }),
+    ];
+    const result = validate(events);
+    const issue = result.issues.find(i => i.code === ISSUE_CODES.CONFLICTING_TRACE_CONTEXT);
+    assert.ok(issue, 'Expected conflicting_trace_context with no session.start');
+  });
+
+  await test('issue context includes correlation_ids array', async () => {
+    const events = [
+      evt({ event_id: 'e-001', correlation_id: CID_A, metadata: { tool_name: 'get_me' } }),
+      evt({ event_id: 'e-002', correlation_id: CID_B, metadata: { tool_name: 'get_me' } }),
+    ];
+    const result = validate(events);
+    const issue = result.issues.find(i => i.code === ISSUE_CODES.CONFLICTING_TRACE_CONTEXT);
+    assert.ok(issue);
+    assert.ok(Array.isArray(issue.context.correlation_ids));
+    assert.ok(issue.context.correlation_ids.includes(CID_A));
+    assert.ok(issue.context.correlation_ids.includes(CID_B));
+  });
+
+  await test('single uniform CID across all events is not flagged', async () => {
+    const result = validate(cleanSession());
+    const issue = result.issues.find(i => i.code === ISSUE_CODES.CONFLICTING_TRACE_CONTEXT);
+    assert.strictEqual(issue, undefined);
+  });
+
+  await test('two distinct CIDs with two session.starts is not flagged (multi-session)', async () => {
+    // distinct_cids (2) equals session_start_count (2) → not flagged
+    const events = [
+      evt({ event_id: 'e-001', event_type: 'session.start',   correlation_id: CID_A, action: 'mcp_session_init', metadata: {} }),
+      evt({ event_id: 'e-002', event_type: 'tool.invocation', correlation_id: CID_A, metadata: { tool_name: 'get_me' } }),
+      evt({ event_id: 'e-003', event_type: 'session.start',   correlation_id: CID_B, action: 'mcp_session_init', metadata: {} }),
+      evt({ event_id: 'e-004', event_type: 'tool.invocation', correlation_id: CID_B, metadata: { tool_name: 'get_me' } }),
+    ];
+    const result = checkTraceContextConsistency(events);
+    assert.strictEqual(result.issues.length, 0, 'Two matching session starts should not trigger conflicting context');
+  });
+
+  // ── 5. Rule 4 — Unlinked control events ──────────────────────────────────
+
+  console.log('\n5. Rule 4 — unlinked_denial_event / unlinked_approval_event');
+
+  await test('denial event with unique CID in multi-event trace is flagged', async () => {
+    const events = [
+      evt({ event_id: 'e-001', event_type: 'session.start', correlation_id: CID_A, action: 'mcp_session_init', metadata: {} }),
+      evt({ event_id: 'e-002', event_type: 'tool.denial',   correlation_id: CID_B, action: 'delete_branch',    status: 'failure', metadata: { tool_name: 'delete_branch' } }),
+      evt({ event_id: 'e-003', event_type: 'session.end',   correlation_id: CID_A, action: 'mcp_session_close', metadata: {} }),
+    ];
+    const result = validate(events);
+    const issue = result.issues.find(i => i.code === ISSUE_CODES.UNLINKED_DENIAL_EVENT);
+    assert.ok(issue, 'Expected unlinked_denial_event');
+    assert.strictEqual(issue.context.correlation_id, CID_B);
+    assert.strictEqual(issue.context.tool_name, 'delete_branch');
+  });
+
+  await test('approval event with unique CID in multi-event trace is flagged', async () => {
+    const events = [
+      evt({ event_id: 'e-001', event_type: 'session.start',         correlation_id: CID_A, action: 'mcp_session_init',  metadata: {} }),
+      evt({ event_id: 'e-002', event_type: 'tool.approval_granted', correlation_id: CID_B, action: 'merge_pull_request', metadata: { tool_name: 'merge_pull_request' } }),
+      evt({ event_id: 'e-003', event_type: 'session.end',           correlation_id: CID_A, action: 'mcp_session_close',  metadata: {} }),
+    ];
+    const result = validate(events);
+    const issue = result.issues.find(i => i.code === ISSUE_CODES.UNLINKED_APPROVAL_EVENT);
+    assert.ok(issue, 'Expected unlinked_approval_event');
+    assert.strictEqual(issue.context.correlation_id, CID_B);
+  });
+
+  await test('denial event with shared CID is not flagged as unlinked', async () => {
+    const result = validate(denialSession());
+    const issue = result.issues.find(i => i.code === ISSUE_CODES.UNLINKED_DENIAL_EVENT);
+    assert.strictEqual(issue, undefined);
+  });
+
+  await test('approval event with shared CID is not flagged as unlinked', async () => {
+    const result = validate(approvalSession());
+    const issue = result.issues.find(i => i.code === ISSUE_CODES.UNLINKED_APPROVAL_EVENT);
+    assert.strictEqual(issue, undefined);
+  });
+
+  await test('single-event denial trace is not flagged as unlinked (solo records are valid)', async () => {
+    const events = [
+      evt({ event_id: 'e-001', event_type: 'tool.denial', correlation_id: CID_A, action: 'delete_branch', status: 'failure', metadata: { tool_name: 'delete_branch' } }),
+    ];
+    const result = validate(events);
+    const issue = result.issues.find(i => i.code === ISSUE_CODES.UNLINKED_DENIAL_EVENT);
+    assert.strictEqual(issue, undefined, 'Single-event trace should not be flagged as unlinked');
+  });
+
+  await test('single-event approval trace is not flagged as unlinked', async () => {
+    const events = [
+      evt({ event_id: 'e-001', event_type: 'tool.approval_granted', correlation_id: CID_A, action: 'merge_pull_request', metadata: { tool_name: 'merge_pull_request' } }),
+    ];
+    const result = validate(events);
+    const issue = result.issues.find(i => i.code === ISSUE_CODES.UNLINKED_APPROVAL_EVENT);
+    assert.strictEqual(issue, undefined, 'Single-event trace should not be flagged as unlinked');
+  });
+
+  // ── 6. Edge cases ─────────────────────────────────────────────────────────
+
+  console.log('\n6. Edge cases');
+
+  await test('non-array input returns valid:false with invalid_input issue', async () => {
+    const result = validate('not-an-array');
+    assert.strictEqual(result.valid, false);
+    assert.ok(result.issues.some(i => i.code === ISSUE_CODES.INVALID_INPUT));
+  });
+
+  await test('null input returns valid:false with invalid_input issue', async () => {
+    const result = validate(null);
+    assert.strictEqual(result.valid, false);
+    assert.ok(result.issues.some(i => i.code === ISSUE_CODES.INVALID_INPUT));
+  });
+
+  await test('ISSUE_CODES are all non-empty strings', async () => {
+    for (const [key, value] of Object.entries(ISSUE_CODES)) {
+      assert.strictEqual(typeof value, 'string', `Expected ISSUE_CODES.${key} to be a string`);
+      assert.ok(value.length > 0, `Expected ISSUE_CODES.${key} to be non-empty`);
+    }
+  });
+
+  await test('all expected ISSUE_CODES are present', async () => {
+    const expected = [
+      'INVALID_INPUT',
+      'MISSING_CORRELATION_ID',
+      'INCONSISTENT_CORRELATION_ID',
+      'CONFLICTING_TRACE_CONTEXT',
+      'UNLINKED_DENIAL_EVENT',
+      'UNLINKED_APPROVAL_EVENT',
+    ];
+    for (const key of expected) {
+      assert.ok(key in ISSUE_CODES, `Expected ISSUE_CODES.${key} to exist`);
+    }
+  });
+
+  await test('events with undefined correlation_id (missing key) are flagged', async () => {
+    const badEvt = { event_id: 'e-001', event_type: 'tool.invocation', timestamp: 't', platform: 'p', project_id: 'p', agent_id: 'a', mcp_server: 's', action: 'x', status: 'success', metadata: {} };
+    // correlation_id key is entirely absent
+    const result = validate([ badEvt ]);
+    const issue = result.issues.find(i => i.code === ISSUE_CODES.MISSING_CORRELATION_ID);
+    assert.ok(issue, 'Expected missing_correlation_id for event with no correlation_id key');
+  });
+
+  // ── 7. Individual rule exports ────────────────────────────────────────────
+
+  console.log('\n7. Individual rule exports — callable and return correct shape');
+
+  await test('checkCorrelationPresence returns { issues, warnings }', async () => {
+    const result = checkCorrelationPresence([evt()]);
+    assert.ok(Array.isArray(result.issues));
+    assert.ok(Array.isArray(result.warnings));
+  });
+
+  await test('checkSessionActivityAlignment returns { issues, warnings }', async () => {
+    const result = checkSessionActivityAlignment([]);
+    assert.ok(Array.isArray(result.issues));
+    assert.ok(Array.isArray(result.warnings));
+  });
+
+  await test('checkTraceContextConsistency returns { issues, warnings }', async () => {
+    const result = checkTraceContextConsistency([]);
+    assert.ok(Array.isArray(result.issues));
+    assert.ok(Array.isArray(result.warnings));
+  });
+
+  await test('checkUnlinkedControlEvents returns { issues, warnings }', async () => {
+    const result = checkUnlinkedControlEvents([]);
+    assert.ok(Array.isArray(result.issues));
+    assert.ok(Array.isArray(result.warnings));
+  });
+
+  // ── 8. Regression: prior validator tests unaffected ──────────────────────
+
+  console.log('\n8. Regression — completeness validator unaffected');
+
+  await test('completeness validator still loads and validate() returns expected shape', async () => {
+    const completeness = require('../src/detection/event-completeness-validator');
+    const result = completeness.validate([]);
+    assert.strictEqual(result.complete, true);
+    assert.ok(Array.isArray(result.issues));
+  });
+
+  // ── Summary ───────────────────────────────────────────────────────────────
+
+  const bar = '─'.repeat(40);
+  console.log(`\n${bar}`);
+  console.log(`Results: ${passed} passed, ${failed} failed`);
+  if (failed > 0) process.exit(1);
+
+})().catch(err => {
+  console.error('\nValidation script crashed:', err.message);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- Introduces `src/detection/correlation-integrity-validator.js` — a pure validator that checks whether correlation linkage is internally consistent across events in a trace
- Complements the completeness validator (TD-HMCP-000003): completeness checks event *presence*, integrity checks event *linkage*
- Four rules: correlation presence, session activity alignment, trace context consistency, unlinked control events
- Exports stable `ISSUE_CODES` and individual rule functions following the same pattern as the completeness validator
- 38 tests; all prior test suites pass without modification

## Changes

- `src/detection/correlation-integrity-validator.js` — four-rule validator; `validate()` entry point; `ISSUE_CODES` constants; exported rule functions
- `tests/validate-correlation-integrity.js` — 38 tests across 8 groups including a regression check for the completeness validator
- `docs/detection/correlation-integrity-checks.md` — full documentation: rules, result shape, issue codes, relationship to completeness validator, future extension points

## Test plan

- [x] `node tests/validate-correlation-integrity.js` — 38 passed, 0 failed
- [x] `node tests/validate-event-completeness.js` — 33 passed, 0 failed (regression)
- [x] `node tests/validate-approval-gate.js` — 24 passed, 0 failed (regression)
- [x] `node tests/validate-policy-gate.js` — 21 passed, 0 failed (regression)

Implements: CC-HMCP-000013 / TD-HMCP-000004

🤖 Generated with [Claude Code](https://claude.com/claude-code)