### PR TITLE
feat: implement session anomaly detection (TD-HMCP-000001)

### DIFF
--- a/docs/detection/session-anomaly-detection.md
+++ b/docs/detection/session-anomaly-detection.md
@@ -1,0 +1,192 @@
+# Session Anomaly Detection — TD-HMCP-000001
+
+## Purpose
+
+The session anomaly detector examines a session trace and identifies behavioral patterns that are unusual or suspicious according to explicit, deterministic rules.
+
+This is not a statistical or machine-learning anomaly engine. It is a first detection layer — rule-based, auditable, and narrowly scoped. Every finding is the result of an explicit condition that a human can read, understand, and verify.
+
+The anomaly detector answers the question:
+
+> "Given these events, does this session's behavior look suspicious according to the platform's current rules?"
+
+---
+
+## Relationship to Completeness and Integrity Validators
+
+The three detection layers are independent and complementary:
+
+| Layer | Module | Result | Checks |
+|---|---|---|---|
+| Completeness | `event-completeness-validator` | `complete: boolean` | Are expected event types present? |
+| Integrity | `correlation-integrity-validator` | `valid: boolean` | Are events correctly linked via `correlation_id`? |
+| Anomaly (this) | `session-anomaly-detector` | `anomalous: boolean` | Does the session's behavioral pattern look suspicious? |
+
+A trace can be complete and integrity-valid but still anomalous. For example: all required events are present, all `correlation_id`s are consistent, but the session contains ten denied actions — that is structurally fine but behaviorally suspicious.
+
+**Intended usage:** run the anomaly detector on traces that are already sufficiently complete and correlation-valid. Running it on structurally broken traces may produce findings that reflect structural problems rather than behavioral ones, which can be misleading. The anomaly detector can also be run independently — findings are meaningful on partial traces.
+
+---
+
+## What Session Anomaly Detection Checks
+
+Five rules are evaluated:
+
+### Rule 1 — Repeated Policy Denials
+
+A session with `≥ 3` `tool.denial` events indicates unusual concentration of blocked actions. In normal operation a session has zero or one denial. Multiple denials suggest repeated attempts against a blocked tool, a misconfigured caller, or probing behavior.
+
+Threshold: `THRESHOLDS.REPEATED_DENIALS = 3`
+Finding code: `repeated_policy_denials`
+
+---
+
+### Rule 2 — Approval Without Follow-Through
+
+A `tool.approval_granted` event with no corresponding `tool.invocation` for the same tool and `correlation_id` means approval was explicitly obtained but the tool was never called. This may indicate an aborted attempt, a scripting error, or approval being obtained speculatively.
+
+Finding code: `approval_without_followthrough`
+
+---
+
+### Rule 3 — Conflicting Control Outcomes
+
+When the same tool was denied in a session AND also invoked in the same session with no `tool.approval_granted` evidence, the session contains contradictory policy outcomes. This suggests either a policy bypass (tool invoked without going through the approval gate) or a trace assembly problem.
+
+The normal approval flow — `tool.denial` (requires_approval) → `tool.approval_granted` → `tool.invocation` — is **not** flagged. Approval evidence makes the progression legitimate. Only denial + invocation with no approval for that tool triggers this finding.
+
+Finding code: `conflicting_control_outcomes`
+
+---
+
+### Rule 4 — Control-Event-Heavy Session
+
+A session where control events (denials + approvals) significantly outnumber actual invocations indicates the session spent more time encountering policy gates than performing useful work. This may signal a misconfigured caller, probing behavior, or an unusual workflow.
+
+Fires when: `control_count >= 3` AND `control_count > invocation_count + 2`
+
+Thresholds: `THRESHOLDS.CONTROL_HEAVY_MIN = 3`, `THRESHOLDS.CONTROL_HEAVY_MARGIN = 2`
+Finding code: `control_event_heavy_session`
+
+---
+
+### Rule 5 — Excessive Tool Activity
+
+A session with more than `50` total tool events (invocations + denials + approvals combined) is unusually active for a single session. This may indicate runaway automation, a looping script, or a session that should have been split into multiple workflows.
+
+Session framing events (`session.start`, `session.end`) are not counted.
+Threshold: `THRESHOLDS.EXCESSIVE_TOOL_ACTIVITY = 50`
+Finding code: `excessive_tool_activity`
+
+---
+
+## What Session Anomaly Detection Is NOT Checking
+
+This detector does not:
+
+- **Use statistics or machine learning** — all rules are explicit conditions; no baselining or scoring
+- **Compare across sessions** — each trace is evaluated independently; no multi-session trend analysis
+- **Check event presence or linkage** — structural completeness and correlation integrity are the responsibility of the other validators
+- **Apply real-time alerting** — the detector returns findings; routing and alerting are out of scope
+- **Validate field integrity** — missing fields or invalid event formats are the completeness validator's responsibility
+- **Detect all possible anomalies** — only the five rules above are currently implemented
+
+---
+
+## Detection Rules Summary
+
+| Rule | Finding Code | Trigger Condition |
+|---|---|---|
+| Repeated denials | `repeated_policy_denials` | ≥ 3 `tool.denial` events in trace |
+| Approval without follow-through | `approval_without_followthrough` | `tool.approval_granted` with no matching `tool.invocation` (same tool, same `correlation_id`) |
+| Conflicting control outcomes | `conflicting_control_outcomes` | Same tool denied AND invoked with no `tool.approval_granted` |
+| Control-event-heavy session | `control_event_heavy_session` | (denials + approvals) ≥ 3 AND > invocations + 2 |
+| Excessive tool activity | `excessive_tool_activity` | Total tool events > 50 |
+| Invalid input | `invalid_input` | Input is not an array |
+
+---
+
+## Detector Result Shape
+
+```js
+const { detect } = require('./src/detection/session-anomaly-detector');
+const result = detect(events);
+```
+
+```json
+{
+  "anomalous": true,
+  "findings": [
+    {
+      "code": "repeated_policy_denials",
+      "message": "Session contains 4 policy denial events (threshold: 3)",
+      "context": {
+        "denial_count": 4,
+        "threshold": 3,
+        "denied_tools": ["delete_branch"]
+      }
+    }
+  ],
+  "warnings": []
+}
+```
+
+- `anomalous: true` — one or more findings; session behavior is suspicious according to current rules
+- `anomalous: false` — no findings; session behavior is within expected parameters
+- `findings` — each finding has a stable `code`, human-readable `message`, and optional `context`
+- `warnings` — advisory findings (reserved; currently empty)
+
+---
+
+## Stable Finding Codes and Thresholds
+
+```js
+const { FINDING_CODES, THRESHOLDS } = require('./src/detection/session-anomaly-detector');
+```
+
+| Constant | Code |
+|---|---|
+| `INVALID_INPUT` | `invalid_input` |
+| `REPEATED_POLICY_DENIALS` | `repeated_policy_denials` |
+| `APPROVAL_WITHOUT_FOLLOWTHROUGH` | `approval_without_followthrough` |
+| `CONFLICTING_CONTROL_OUTCOMES` | `conflicting_control_outcomes` |
+| `CONTROL_EVENT_HEAVY_SESSION` | `control_event_heavy_session` |
+| `EXCESSIVE_TOOL_ACTIVITY` | `excessive_tool_activity` |
+
+| Threshold | Value | Applies To |
+|---|---|---|
+| `REPEATED_DENIALS` | 3 | Minimum denial count to trigger `repeated_policy_denials` |
+| `CONTROL_HEAVY_MIN` | 3 | Minimum control events before `control_event_heavy_session` can fire |
+| `CONTROL_HEAVY_MARGIN` | 2 | Required excess of control events over invocations |
+| `EXCESSIVE_TOOL_ACTIVITY` | 50 | Maximum tool events before `excessive_tool_activity` fires |
+
+---
+
+## How This Supports Future Work
+
+### Expanded Rule Set
+
+New rules can be added as new `RULES` entries following the same `(events) → { findings, warnings }` pattern. Existing rules are unaffected. Candidates for future rules include:
+
+- secret retrieval anomalies (multiple retrieval failures, unusual retrieval mechanisms)
+- session duration anomalies (unusually long or short sessions, if timestamps are used)
+- tool sequence anomalies (unexpected ordering of tool calls within a session)
+- approval obtained for a tool not present in the tool registry
+
+### Higher-Level Audit Validation
+
+A composable `auditTrace(events)` function could run all three detection layers (completeness, integrity, anomaly) and return a unified result. The three modules use compatible structural patterns (`{ findings/issues, warnings }` rule shape, stable code constants) and can be combined cleanly.
+
+### Multi-Session Analysis
+
+Once the platform supports multi-session trace decomposition (grouping events by `correlation_id`), the anomaly detector can be applied per-session to a batch of sessions, and cross-session patterns (e.g., repeated denials from the same agent across sessions) can be detected at a higher layer.
+
+---
+
+## Module Location
+
+```
+src/detection/session-anomaly-detector.js
+```
+
+Tests: `tests/validate-session-anomaly-detection.js`

--- a/src/detection/session-anomaly-detector.js
+++ b/src/detection/session-anomaly-detector.js
@@ -1,0 +1,372 @@
+'use strict';
+
+/**
+ * Home MCP Compliance Lab — Session Anomaly Detector (TD-HMCP-000001)
+ *
+ * Detects anomalous behavioral patterns in a session trace using explicit,
+ * deterministic rules. Operates on traces already considered sufficiently
+ * complete and correlation-valid (see completeness and integrity validators).
+ *
+ * Relationship to existing validators:
+ *   Completeness  — are the expected event types present?
+ *   Integrity     — are the events correctly linked via correlation_id?
+ *   Anomaly (this) — do the events that exist form a suspicious behavioral pattern?
+ *
+ * These three layers are independent. A trace can be complete and valid but
+ * still anomalous (e.g., correct structure, correct linkage, but 10 denials
+ * in one session). Run all three for full audit trust.
+ *
+ * Rules evaluated:
+ *   1. Repeated denials          — session contains ≥ THRESHOLDS.REPEATED_DENIALS
+ *                                  tool.denial events; concentration of denied
+ *                                  actions is unusual in normal operation
+ *   2. Approval without          — tool.approval_granted with no corresponding
+ *      follow-through              tool.invocation; approval obtained but tool
+ *                                  never used
+ *   3. Conflicting control       — the same tool was denied and invoked in the
+ *      outcomes                    session with no approval evidence; suggests
+ *                                  a policy bypass or unrecorded approval
+ *   4. Control-event-heavy       — control events (denials + approvals) heavily
+ *      session                     outnumber actual invocations; session dominated
+ *                                  by policy activity rather than productive work
+ *   5. Excessive tool activity   — total tool events exceed THRESHOLDS.EXCESSIVE_TOOL_ACTIVITY;
+ *                                  unusually high activity for a single session
+ *
+ * Pure module — no file I/O, no external calls, no side effects.
+ *
+ * Usage:
+ *   const { detect } = require('./session-anomaly-detector');
+ *   const result = detect(events);
+ *   // { anomalous: boolean, findings: Array<Finding>, warnings: Array<Warning> }
+ *
+ * Result shape:
+ *   {
+ *     anomalous: boolean    — true when findings is non-empty
+ *     findings:  Finding[]  — anomaly detections; each describes a suspicious pattern
+ *     warnings:  Warning[]  — advisory findings (reserved; currently empty)
+ *   }
+ *
+ * Finding shape:
+ *   {
+ *     code:     string   — stable machine-readable code (see FINDING_CODES)
+ *     message:  string   — human-readable description
+ *     context:  object   — optional — counts, tool names, event IDs, thresholds
+ *   }
+ */
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+/**
+ * Stable finding codes for session anomaly detections.
+ */
+const FINDING_CODES = {
+  INVALID_INPUT:                  'invalid_input',
+  REPEATED_POLICY_DENIALS:        'repeated_policy_denials',
+  APPROVAL_WITHOUT_FOLLOWTHROUGH: 'approval_without_followthrough',
+  CONFLICTING_CONTROL_OUTCOMES:   'conflicting_control_outcomes',
+  CONTROL_EVENT_HEAVY_SESSION:    'control_event_heavy_session',
+  EXCESSIVE_TOOL_ACTIVITY:        'excessive_tool_activity',
+};
+
+/**
+ * Thresholds used by rule evaluations.
+ * Exported for reference in tests and documentation.
+ */
+const THRESHOLDS = {
+  // Minimum tool.denial count that triggers repeated_policy_denials.
+  REPEATED_DENIALS: 3,
+
+  // Minimum control event count required before control_event_heavy_session can fire.
+  CONTROL_HEAVY_MIN: 3,
+
+  // Control events must exceed invocations by at least this margin to trigger
+  // control_event_heavy_session.
+  CONTROL_HEAVY_MARGIN: 2,
+
+  // Maximum total tool events (invocations + denials + approvals) before
+  // excessive_tool_activity is flagged.
+  EXCESSIVE_TOOL_ACTIVITY: 50,
+};
+
+// ── Finding / warning factories ───────────────────────────────────────────────
+
+function mkFinding(code, message, context) {
+  const result = { code, message };
+  if (context != null) result.context = context;
+  return result;
+}
+
+// Reserved for future advisory findings.
+// eslint-disable-next-line no-unused-vars
+function mkWarning(code, message, context) {
+  const result = { code, message };
+  if (context != null) result.context = context;
+  return result;
+}
+
+// ── Helper ────────────────────────────────────────────────────────────────────
+
+function toolNameOf(event) {
+  return (event.metadata && event.metadata.tool_name) || event.action || null;
+}
+
+// ── Rules ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Rule 1 — Repeated Policy Denials
+ *
+ * A session with ≥ THRESHOLDS.REPEATED_DENIALS tool.denial events indicates
+ * unusual concentration of blocked actions. In normal operation a session will
+ * have zero or one denial; multiple denials suggest either repeated attempts
+ * against a blocked tool or a misconfigured caller.
+ *
+ * Findings: repeated_policy_denials
+ */
+function checkRepeatedDenials(events) {
+  const findings = [];
+
+  const denials = events.filter(e => e.event_type === 'tool.denial');
+  if (denials.length >= THRESHOLDS.REPEATED_DENIALS) {
+    const deniedTools = [...new Set(denials.map(toolNameOf).filter(Boolean))];
+    findings.push(mkFinding(
+      FINDING_CODES.REPEATED_POLICY_DENIALS,
+      `Session contains ${denials.length} policy denial events (threshold: ${THRESHOLDS.REPEATED_DENIALS})`,
+      {
+        denial_count: denials.length,
+        threshold:    THRESHOLDS.REPEATED_DENIALS,
+        denied_tools: deniedTools,
+      }
+    ));
+  }
+
+  return { findings, warnings: [] };
+}
+
+/**
+ * Rule 2 — Approval Without Follow-Through
+ *
+ * A tool.approval_granted event that has no corresponding tool.invocation for
+ * the same tool within the same correlation scope is suspicious. Approval was
+ * explicitly obtained but the tool was never called. This may indicate an
+ * aborted attempt, a scripting error, or approval being obtained speculatively.
+ *
+ * Findings: approval_without_followthrough
+ */
+function checkApprovalWithoutFollowthrough(events) {
+  const findings = [];
+
+  const approvals = events.filter(e => e.event_type === 'tool.approval_granted');
+
+  for (const approval of approvals) {
+    const toolName = toolNameOf(approval);
+    const cid = approval.correlation_id;
+
+    const hasInvocation = events.some(e =>
+      e.event_type === 'tool.invocation' &&
+      toolNameOf(e) === toolName &&
+      e.correlation_id === cid
+    );
+
+    if (!hasInvocation) {
+      findings.push(mkFinding(
+        FINDING_CODES.APPROVAL_WITHOUT_FOLLOWTHROUGH,
+        `Approval granted for "${toolName}" but no corresponding tool.invocation found`,
+        {
+          tool_name:         toolName,
+          approval_event_id: approval.event_id,
+          correlation_id:    cid,
+        }
+      ));
+    }
+  }
+
+  return { findings, warnings: [] };
+}
+
+/**
+ * Rule 3 — Conflicting Control Outcomes
+ *
+ * When the same tool was denied in a session AND also invoked in the same
+ * session with no approval evidence, the session contains contradictory policy
+ * outcomes. This suggests either:
+ *   - a policy bypass (tool was invoked without going through the approval gate)
+ *   - a trace assembly issue (denial and invocation are from different paths)
+ *
+ * The normal approval flow (denied → approval_granted → invoked) is NOT flagged:
+ * approval evidence makes the progression legitimate. Only denial + invocation
+ * with no approval evidence for that tool triggers this finding.
+ *
+ * Findings: conflicting_control_outcomes
+ */
+function checkConflictingControlOutcomes(events) {
+  const findings = [];
+
+  const deniedToolNames = new Set(
+    events
+      .filter(e => e.event_type === 'tool.denial')
+      .map(toolNameOf)
+      .filter(Boolean)
+  );
+
+  for (const toolName of deniedToolNames) {
+    const hasInvocation = events.some(
+      e => e.event_type === 'tool.invocation' && toolNameOf(e) === toolName
+    );
+    const hasApproval = events.some(
+      e => e.event_type === 'tool.approval_granted' && toolNameOf(e) === toolName
+    );
+
+    if (hasInvocation && !hasApproval) {
+      const denialEvt     = events.find(e => e.event_type === 'tool.denial'     && toolNameOf(e) === toolName);
+      const invocationEvt = events.find(e => e.event_type === 'tool.invocation' && toolNameOf(e) === toolName);
+
+      findings.push(mkFinding(
+        FINDING_CODES.CONFLICTING_CONTROL_OUTCOMES,
+        `Tool "${toolName}" was both denied and invoked in this session with no approval evidence`,
+        {
+          tool_name:           toolName,
+          denial_event_id:     denialEvt     ? denialEvt.event_id     : null,
+          invocation_event_id: invocationEvt ? invocationEvt.event_id : null,
+        }
+      ));
+    }
+  }
+
+  return { findings, warnings: [] };
+}
+
+/**
+ * Rule 4 — Control-Event-Heavy Session
+ *
+ * A session where control events (denials + approvals) significantly outnumber
+ * actual invocations is suspicious. It indicates the session spent more time
+ * encountering policy gates than performing useful work, which may signal a
+ * misconfigured caller, probing behavior, or an unusual workflow.
+ *
+ * Fires when:
+ *   control_count >= THRESHOLDS.CONTROL_HEAVY_MIN
+ *   AND control_count > invocation_count + THRESHOLDS.CONTROL_HEAVY_MARGIN
+ *
+ * Findings: control_event_heavy_session
+ */
+function checkControlEventHeavySession(events) {
+  const findings = [];
+
+  const denialCount     = events.filter(e => e.event_type === 'tool.denial').length;
+  const approvalCount   = events.filter(e => e.event_type === 'tool.approval_granted').length;
+  const invocationCount = events.filter(e => e.event_type === 'tool.invocation').length;
+  const controlCount    = denialCount + approvalCount;
+
+  if (
+    controlCount >= THRESHOLDS.CONTROL_HEAVY_MIN &&
+    controlCount > invocationCount + THRESHOLDS.CONTROL_HEAVY_MARGIN
+  ) {
+    findings.push(mkFinding(
+      FINDING_CODES.CONTROL_EVENT_HEAVY_SESSION,
+      `Session has ${controlCount} control events (${denialCount} denials, ${approvalCount} approvals) against ${invocationCount} invocations`,
+      {
+        denial_count:     denialCount,
+        approval_count:   approvalCount,
+        invocation_count: invocationCount,
+        control_count:    controlCount,
+      }
+    ));
+  }
+
+  return { findings, warnings: [] };
+}
+
+/**
+ * Rule 5 — Excessive Tool Activity
+ *
+ * A session with more than THRESHOLDS.EXCESSIVE_TOOL_ACTIVITY total tool events
+ * (invocations + denials + approvals combined) is unusually active for a single
+ * session. This may indicate runaway automation, a script looping unexpectedly,
+ * or a session that should have been split across multiple workflows.
+ *
+ * Findings: excessive_tool_activity
+ */
+function checkExcessiveToolActivity(events) {
+  const findings = [];
+
+  const toolEvents = events.filter(e =>
+    e.event_type === 'tool.invocation'       ||
+    e.event_type === 'tool.denial'           ||
+    e.event_type === 'tool.approval_granted'
+  );
+
+  if (toolEvents.length > THRESHOLDS.EXCESSIVE_TOOL_ACTIVITY) {
+    findings.push(mkFinding(
+      FINDING_CODES.EXCESSIVE_TOOL_ACTIVITY,
+      `Session contains ${toolEvents.length} tool events (threshold: ${THRESHOLDS.EXCESSIVE_TOOL_ACTIVITY})`,
+      {
+        tool_event_count: toolEvents.length,
+        threshold:        THRESHOLDS.EXCESSIVE_TOOL_ACTIVITY,
+      }
+    ));
+  }
+
+  return { findings, warnings: [] };
+}
+
+// ── Registered ruleset ────────────────────────────────────────────────────────
+
+const RULES = [
+  checkRepeatedDenials,
+  checkApprovalWithoutFollowthrough,
+  checkConflictingControlOutcomes,
+  checkControlEventHeavySession,
+  checkExcessiveToolActivity,
+];
+
+// ── Detector ──────────────────────────────────────────────────────────────────
+
+/**
+ * Evaluate a sequence of audit events for session anomalies.
+ *
+ * Intended to run on traces already considered complete and correlation-valid.
+ * Can also be run independently; findings are meaningful even on partial traces.
+ *
+ * @param {object[]} events — array of audit event objects
+ * @returns {{ anomalous: boolean, findings: object[], warnings: object[] }}
+ */
+function detect(events) {
+  if (!Array.isArray(events)) {
+    return {
+      anomalous: true,
+      findings: [mkFinding(
+        FINDING_CODES.INVALID_INPUT,
+        'events must be an array',
+        { received: typeof events }
+      )],
+      warnings: [],
+    };
+  }
+
+  const allFindings = [];
+  const allWarnings = [];
+
+  for (const rule of RULES) {
+    const { findings, warnings } = rule(events);
+    allFindings.push(...findings);
+    allWarnings.push(...warnings);
+  }
+
+  return {
+    anomalous: allFindings.length > 0,
+    findings:  allFindings,
+    warnings:  allWarnings,
+  };
+}
+
+module.exports = {
+  detect,
+  FINDING_CODES,
+  THRESHOLDS,
+  // Export individual rules for targeted unit testing.
+  checkRepeatedDenials,
+  checkApprovalWithoutFollowthrough,
+  checkConflictingControlOutcomes,
+  checkControlEventHeavySession,
+  checkExcessiveToolActivity,
+};

--- a/tests/validate-session-anomaly-detection.js
+++ b/tests/validate-session-anomaly-detection.js
@@ -1,0 +1,485 @@
+'use strict';
+
+// Validation tests for TD-HMCP-000001 — Session Anomaly Detection
+//
+// Validates:
+//   1. Normal session traces are not flagged as anomalous
+//   2. Repeated denials beyond threshold trigger repeated_policy_denials
+//   3. Approval without follow-through triggers approval_without_followthrough
+//   4. Denial + invocation with no approval triggers conflicting_control_outcomes
+//   5. Control-heavy sessions trigger control_event_heavy_session
+//   6. Excessive tool activity triggers excessive_tool_activity
+//   7. Threshold boundaries (at/above/below) are correct
+//   8. Malformed inputs handled cleanly
+//   9. Individual rule exports return correct shape
+//  10. Regression: prior validators unaffected
+//
+// No network required. Run: node tests/validate-session-anomaly-detection.js
+
+const assert = require('assert');
+
+let passed = 0;
+let failed = 0;
+
+async function test(name, fn) {
+  try {
+    await fn();
+    console.log(`  [PASS] ${name}`);
+    passed++;
+  } catch (err) {
+    console.error(`  [FAIL] ${name}: ${err.message}`);
+    failed++;
+  }
+}
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const CID = 'sess-20260407-test001';
+
+function evt(overrides) {
+  return {
+    event_id:       `evt-${Math.random().toString(36).slice(2, 9)}`,
+    event_type:     'tool.invocation',
+    timestamp:      '2026-04-07T12:00:00Z',
+    platform:       'home-mcp-lab',
+    project_id:     'home-mcp-lab',
+    agent_id:       'test-agent',
+    mcp_server:     'github-mcp-server',
+    action:         'get_me',
+    status:         'success',
+    correlation_id: CID,
+    metadata:       { tool_name: 'get_me' },
+    ...overrides,
+  };
+}
+
+function sessionStart()   { return evt({ event_type: 'session.start', action: 'mcp_session_init', metadata: {} }); }
+function sessionEnd()     { return evt({ event_type: 'session.end',   action: 'mcp_session_close', metadata: {} }); }
+function invocation(tool) { return evt({ event_type: 'tool.invocation', action: tool, metadata: { tool_name: tool } }); }
+function denial(tool)     { return evt({ event_type: 'tool.denial',     action: tool, status: 'failure', metadata: { tool_name: tool } }); }
+function approval(tool)   { return evt({ event_type: 'tool.approval_granted', action: tool, metadata: { tool_name: tool } }); }
+
+// Normal happy-path session.
+function normalSession() {
+  return [sessionStart(), invocation('get_me'), invocation('list_issues'), sessionEnd()];
+}
+
+// Normal approval-path session (denial → approval → invocation).
+function approvalPathSession() {
+  return [sessionStart(), denial('merge_pull_request'), approval('merge_pull_request'), invocation('merge_pull_request'), sessionEnd()];
+}
+
+// Normal denial-only session (one denial, no invocation of that tool).
+function singleDenialSession() {
+  return [sessionStart(), denial('delete_branch'), sessionEnd()];
+}
+
+// ── Load detector ─────────────────────────────────────────────────────────────
+
+const {
+  detect,
+  FINDING_CODES,
+  THRESHOLDS,
+  checkRepeatedDenials,
+  checkApprovalWithoutFollowthrough,
+  checkConflictingControlOutcomes,
+  checkControlEventHeavySession,
+  checkExcessiveToolActivity,
+} = require('../src/detection/session-anomaly-detector');
+
+// ── 1. Non-anomalous traces ───────────────────────────────────────────────────
+
+(async () => {
+
+  console.log('\n1. Non-anomalous traces — not flagged');
+
+  await test('normal happy-path session is not anomalous', async () => {
+    const result = detect(normalSession());
+    assert.strictEqual(result.anomalous, false, `Unexpected findings: ${JSON.stringify(result.findings)}`);
+    assert.strictEqual(result.findings.length, 0);
+  });
+
+  await test('approval-path session (denial → approval → invocation) is not anomalous', async () => {
+    const result = detect(approvalPathSession());
+    assert.strictEqual(result.anomalous, false, `Unexpected findings: ${JSON.stringify(result.findings)}`);
+  });
+
+  await test('single denial session is not anomalous (below threshold)', async () => {
+    const result = detect(singleDenialSession());
+    assert.strictEqual(result.anomalous, false, `Unexpected findings: ${JSON.stringify(result.findings)}`);
+  });
+
+  await test('empty trace is not anomalous', async () => {
+    const result = detect([]);
+    assert.strictEqual(result.anomalous, false);
+    assert.strictEqual(result.findings.length, 0);
+  });
+
+  await test('result always has anomalous, findings, and warnings fields', async () => {
+    const result = detect([]);
+    assert.ok('anomalous' in result);
+    assert.ok(Array.isArray(result.findings));
+    assert.ok(Array.isArray(result.warnings));
+  });
+
+  // ── 2. Rule 1 — Repeated denials ────────────────────────────────────────
+
+  console.log('\n2. Rule 1 — repeated_policy_denials');
+
+  await test(`${THRESHOLDS.REPEATED_DENIALS} denials triggers repeated_policy_denials`, async () => {
+    const events = [
+      sessionStart(),
+      ...Array.from({ length: THRESHOLDS.REPEATED_DENIALS }, () => denial('delete_branch')),
+      sessionEnd(),
+    ];
+    const result = detect(events);
+    assert.strictEqual(result.anomalous, true);
+    const finding = result.findings.find(f => f.code === FINDING_CODES.REPEATED_POLICY_DENIALS);
+    assert.ok(finding, 'Expected repeated_policy_denials finding');
+    assert.strictEqual(finding.context.denial_count, THRESHOLDS.REPEATED_DENIALS);
+    assert.strictEqual(finding.context.threshold,    THRESHOLDS.REPEATED_DENIALS);
+  });
+
+  await test('denial count exceeding threshold includes denied_tools list', async () => {
+    const events = [
+      denial('delete_branch'),
+      denial('delete_branch'),
+      denial('merge_pull_request'),
+    ];
+    const result = detect(events);
+    const finding = result.findings.find(f => f.code === FINDING_CODES.REPEATED_POLICY_DENIALS);
+    assert.ok(finding);
+    assert.ok(Array.isArray(finding.context.denied_tools));
+    assert.ok(finding.context.denied_tools.includes('delete_branch'));
+    assert.ok(finding.context.denied_tools.includes('merge_pull_request'));
+  });
+
+  await test(`${THRESHOLDS.REPEATED_DENIALS - 1} denials does not trigger repeated_policy_denials`, async () => {
+    const events = Array.from({ length: THRESHOLDS.REPEATED_DENIALS - 1 }, () => denial('delete_branch'));
+    const result = detect(events);
+    const finding = result.findings.find(f => f.code === FINDING_CODES.REPEATED_POLICY_DENIALS);
+    assert.strictEqual(finding, undefined);
+  });
+
+  await test('more denials than threshold also triggers the finding', async () => {
+    const events = Array.from({ length: THRESHOLDS.REPEATED_DENIALS + 2 }, () => denial('delete_branch'));
+    const result = detect(events);
+    const finding = result.findings.find(f => f.code === FINDING_CODES.REPEATED_POLICY_DENIALS);
+    assert.ok(finding);
+    assert.strictEqual(finding.context.denial_count, THRESHOLDS.REPEATED_DENIALS + 2);
+  });
+
+  // ── 3. Rule 2 — Approval without follow-through ──────────────────────────
+
+  console.log('\n3. Rule 2 — approval_without_followthrough');
+
+  await test('approval_granted with no matching invocation is flagged', async () => {
+    const events = [sessionStart(), approval('merge_pull_request'), sessionEnd()];
+    const result = detect(events);
+    assert.strictEqual(result.anomalous, true);
+    const finding = result.findings.find(f => f.code === FINDING_CODES.APPROVAL_WITHOUT_FOLLOWTHROUGH);
+    assert.ok(finding, 'Expected approval_without_followthrough finding');
+    assert.strictEqual(finding.context.tool_name, 'merge_pull_request');
+  });
+
+  await test('approval_granted followed by matching invocation is not flagged', async () => {
+    const result = detect(approvalPathSession());
+    const finding = result.findings.find(f => f.code === FINDING_CODES.APPROVAL_WITHOUT_FOLLOWTHROUGH);
+    assert.strictEqual(finding, undefined);
+  });
+
+  await test('approval and invocation for different tools flags approval_without_followthrough', async () => {
+    // approval for tool A, invocation for tool B — not a match
+    const events = [
+      approval('merge_pull_request'),
+      invocation('create_issue'),
+    ];
+    const result = detect(events);
+    const finding = result.findings.find(f => f.code === FINDING_CODES.APPROVAL_WITHOUT_FOLLOWTHROUGH);
+    assert.ok(finding, 'Expected approval_without_followthrough when tools differ');
+    assert.strictEqual(finding.context.tool_name, 'merge_pull_request');
+  });
+
+  await test('approval and invocation for same tool but different correlation_ids is flagged', async () => {
+    const events = [
+      evt({ event_type: 'tool.approval_granted', action: 'merge_pull_request', correlation_id: 'sess-aaa', metadata: { tool_name: 'merge_pull_request' } }),
+      evt({ event_type: 'tool.invocation',       action: 'merge_pull_request', correlation_id: 'sess-bbb', metadata: { tool_name: 'merge_pull_request' } }),
+    ];
+    const result = detect(events);
+    const finding = result.findings.find(f => f.code === FINDING_CODES.APPROVAL_WITHOUT_FOLLOWTHROUGH);
+    assert.ok(finding, 'Expected approval_without_followthrough when correlation_ids differ');
+  });
+
+  // ── 4. Rule 3 — Conflicting control outcomes ─────────────────────────────
+
+  console.log('\n4. Rule 3 — conflicting_control_outcomes');
+
+  await test('denial + invocation for same tool with no approval is flagged', async () => {
+    const events = [
+      sessionStart(),
+      denial('delete_branch'),
+      invocation('delete_branch'),
+      sessionEnd(),
+    ];
+    const result = detect(events);
+    assert.strictEqual(result.anomalous, true);
+    const finding = result.findings.find(f => f.code === FINDING_CODES.CONFLICTING_CONTROL_OUTCOMES);
+    assert.ok(finding, 'Expected conflicting_control_outcomes finding');
+    assert.strictEqual(finding.context.tool_name, 'delete_branch');
+    assert.ok(finding.context.denial_event_id,     'Expected denial_event_id in context');
+    assert.ok(finding.context.invocation_event_id, 'Expected invocation_event_id in context');
+  });
+
+  await test('denial + approval + invocation for same tool is NOT flagged (normal approval flow)', async () => {
+    const result = detect(approvalPathSession());
+    const finding = result.findings.find(f => f.code === FINDING_CODES.CONFLICTING_CONTROL_OUTCOMES);
+    assert.strictEqual(finding, undefined);
+  });
+
+  await test('denial for tool A + invocation for tool B is not flagged (different tools)', async () => {
+    const events = [
+      denial('delete_branch'),
+      invocation('get_me'),
+    ];
+    const result = detect(events);
+    const finding = result.findings.find(f => f.code === FINDING_CODES.CONFLICTING_CONTROL_OUTCOMES);
+    assert.strictEqual(finding, undefined);
+  });
+
+  await test('denial only (no invocation) is not flagged as conflicting', async () => {
+    const result = detect(singleDenialSession());
+    const finding = result.findings.find(f => f.code === FINDING_CODES.CONFLICTING_CONTROL_OUTCOMES);
+    assert.strictEqual(finding, undefined);
+  });
+
+  // ── 5. Rule 4 — Control-event-heavy session ──────────────────────────────
+
+  console.log('\n5. Rule 4 — control_event_heavy_session');
+
+  await test(`${THRESHOLDS.CONTROL_HEAVY_MIN} denials and 0 invocations triggers control_event_heavy_session`, async () => {
+    const events = Array.from({ length: THRESHOLDS.CONTROL_HEAVY_MIN }, () => denial('delete_branch'));
+    const result = detect(events);
+    const finding = result.findings.find(f => f.code === FINDING_CODES.CONTROL_EVENT_HEAVY_SESSION);
+    assert.ok(finding, 'Expected control_event_heavy_session finding');
+    assert.strictEqual(finding.context.control_count,    THRESHOLDS.CONTROL_HEAVY_MIN);
+    assert.strictEqual(finding.context.invocation_count, 0);
+  });
+
+  await test('control count just at margin (control = invocations + margin) does NOT trigger', async () => {
+    // control_count must be STRICTLY GREATER than invocations + margin
+    // With margin=2: 1 invocation → need control > 3; control=3 → 3 > 3 is false → not triggered
+    const events = [
+      invocation('get_me'),
+      denial('delete_branch'),
+      denial('delete_branch'),
+      denial('delete_branch'), // control=3, invocations=1; 3 > 1+2=3? No → not triggered
+    ];
+    const result = detect(events);
+    const finding = result.findings.find(f => f.code === FINDING_CODES.CONTROL_EVENT_HEAVY_SESSION);
+    assert.strictEqual(finding, undefined, 'Should not trigger when control == invocations + margin');
+  });
+
+  await test('control count exceeding margin triggers control_event_heavy_session', async () => {
+    // 4 denials, 1 invocation: 4 > 1+2=3 → triggered (and 4 >= 3 min)
+    const events = [
+      invocation('get_me'),
+      denial('delete_branch'),
+      denial('delete_branch'),
+      denial('delete_branch'),
+      denial('delete_branch'),
+    ];
+    const result = detect(events);
+    const finding = result.findings.find(f => f.code === FINDING_CODES.CONTROL_EVENT_HEAVY_SESSION);
+    assert.ok(finding, 'Expected control_event_heavy_session finding');
+  });
+
+  await test('2 denials and 0 invocations does NOT trigger (below CONTROL_HEAVY_MIN)', async () => {
+    const events = [denial('delete_branch'), denial('delete_branch')];
+    const result = detect(events);
+    const finding = result.findings.find(f => f.code === FINDING_CODES.CONTROL_EVENT_HEAVY_SESSION);
+    assert.strictEqual(finding, undefined, 'Should not trigger below CONTROL_HEAVY_MIN');
+  });
+
+  await test('approvals count toward control-heavy check', async () => {
+    // 2 approvals + 1 denial = 3 control events, 0 invocations → triggered
+    const events = [
+      approval('merge_pull_request'),
+      approval('merge_pull_request'),
+      denial('delete_branch'),
+    ];
+    const result = detect(events);
+    const finding = result.findings.find(f => f.code === FINDING_CODES.CONTROL_EVENT_HEAVY_SESSION);
+    assert.ok(finding, 'Approvals should count toward control_event_heavy_session');
+    assert.strictEqual(finding.context.approval_count, 2);
+    assert.strictEqual(finding.context.denial_count,   1);
+  });
+
+  // ── 6. Rule 5 — Excessive tool activity ──────────────────────────────────
+
+  console.log('\n6. Rule 5 — excessive_tool_activity');
+
+  await test(`${THRESHOLDS.EXCESSIVE_TOOL_ACTIVITY + 1} tool events triggers excessive_tool_activity`, async () => {
+    const events = Array.from(
+      { length: THRESHOLDS.EXCESSIVE_TOOL_ACTIVITY + 1 },
+      () => invocation('get_me')
+    );
+    const result = detect(events);
+    const finding = result.findings.find(f => f.code === FINDING_CODES.EXCESSIVE_TOOL_ACTIVITY);
+    assert.ok(finding, 'Expected excessive_tool_activity finding');
+    assert.strictEqual(finding.context.tool_event_count, THRESHOLDS.EXCESSIVE_TOOL_ACTIVITY + 1);
+    assert.strictEqual(finding.context.threshold,        THRESHOLDS.EXCESSIVE_TOOL_ACTIVITY);
+  });
+
+  await test(`exactly ${THRESHOLDS.EXCESSIVE_TOOL_ACTIVITY} tool events does NOT trigger (threshold is exclusive)`, async () => {
+    const events = Array.from(
+      { length: THRESHOLDS.EXCESSIVE_TOOL_ACTIVITY },
+      () => invocation('get_me')
+    );
+    const result = detect(events);
+    const finding = result.findings.find(f => f.code === FINDING_CODES.EXCESSIVE_TOOL_ACTIVITY);
+    assert.strictEqual(finding, undefined, 'Should not trigger at exactly the threshold');
+  });
+
+  await test('denials and approvals count toward excessive tool activity', async () => {
+    // Mix of invocations, denials, approvals
+    const events = [
+      ...Array.from({ length: 20 }, () => invocation('get_me')),
+      ...Array.from({ length: 16 }, () => denial('delete_branch')),
+      ...Array.from({ length: 15 }, () => approval('merge_pull_request')),
+      // total: 51
+    ];
+    const result = detect(events);
+    const finding = result.findings.find(f => f.code === FINDING_CODES.EXCESSIVE_TOOL_ACTIVITY);
+    assert.ok(finding, 'Expected excessive_tool_activity for mixed tool events');
+    assert.strictEqual(finding.context.tool_event_count, 51);
+  });
+
+  await test('session events (start/end) do NOT count toward excessive tool activity', async () => {
+    // 50 invocations + session.start + session.end = 52 total events, 50 tool events → not triggered
+    const events = [
+      sessionStart(),
+      ...Array.from({ length: THRESHOLDS.EXCESSIVE_TOOL_ACTIVITY }, () => invocation('get_me')),
+      sessionEnd(),
+    ];
+    const result = detect(events);
+    const finding = result.findings.find(f => f.code === FINDING_CODES.EXCESSIVE_TOOL_ACTIVITY);
+    assert.strictEqual(finding, undefined, 'session.start/end should not count as tool events');
+  });
+
+  // ── 7. Edge cases ─────────────────────────────────────────────────────────
+
+  console.log('\n7. Edge cases');
+
+  await test('non-array input returns anomalous:true with invalid_input finding', async () => {
+    const result = detect('not-an-array');
+    assert.strictEqual(result.anomalous, true);
+    assert.ok(result.findings.some(f => f.code === FINDING_CODES.INVALID_INPUT));
+  });
+
+  await test('null input returns anomalous:true with invalid_input finding', async () => {
+    const result = detect(null);
+    assert.strictEqual(result.anomalous, true);
+    assert.ok(result.findings.some(f => f.code === FINDING_CODES.INVALID_INPUT));
+  });
+
+  await test('FINDING_CODES are all non-empty strings', async () => {
+    for (const [key, value] of Object.entries(FINDING_CODES)) {
+      assert.strictEqual(typeof value, 'string', `Expected FINDING_CODES.${key} to be a string`);
+      assert.ok(value.length > 0, `Expected FINDING_CODES.${key} to be non-empty`);
+    }
+  });
+
+  await test('all expected FINDING_CODES are present', async () => {
+    const expected = [
+      'INVALID_INPUT',
+      'REPEATED_POLICY_DENIALS',
+      'APPROVAL_WITHOUT_FOLLOWTHROUGH',
+      'CONFLICTING_CONTROL_OUTCOMES',
+      'CONTROL_EVENT_HEAVY_SESSION',
+      'EXCESSIVE_TOOL_ACTIVITY',
+    ];
+    for (const key of expected) {
+      assert.ok(key in FINDING_CODES, `Expected FINDING_CODES.${key} to exist`);
+    }
+  });
+
+  await test('THRESHOLDS are all positive numbers', async () => {
+    for (const [key, value] of Object.entries(THRESHOLDS)) {
+      assert.strictEqual(typeof value, 'number', `Expected THRESHOLDS.${key} to be a number`);
+      assert.ok(value > 0, `Expected THRESHOLDS.${key} to be positive`);
+    }
+  });
+
+  await test('multiple rules can fire in the same trace', async () => {
+    // 3 denials (repeated_policy_denials) + 0 invocations (control_event_heavy_session)
+    const events = Array.from({ length: THRESHOLDS.REPEATED_DENIALS }, () => denial('delete_branch'));
+    const result = detect(events);
+    assert.strictEqual(result.anomalous, true);
+    const codes = result.findings.map(f => f.code);
+    assert.ok(codes.includes(FINDING_CODES.REPEATED_POLICY_DENIALS));
+    assert.ok(codes.includes(FINDING_CODES.CONTROL_EVENT_HEAVY_SESSION));
+  });
+
+  // ── 8. Individual rule exports ────────────────────────────────────────────
+
+  console.log('\n8. Individual rule exports — callable and return correct shape');
+
+  await test('checkRepeatedDenials returns { findings, warnings }', async () => {
+    const result = checkRepeatedDenials([]);
+    assert.ok(Array.isArray(result.findings));
+    assert.ok(Array.isArray(result.warnings));
+  });
+
+  await test('checkApprovalWithoutFollowthrough returns { findings, warnings }', async () => {
+    const result = checkApprovalWithoutFollowthrough([]);
+    assert.ok(Array.isArray(result.findings));
+    assert.ok(Array.isArray(result.warnings));
+  });
+
+  await test('checkConflictingControlOutcomes returns { findings, warnings }', async () => {
+    const result = checkConflictingControlOutcomes([]);
+    assert.ok(Array.isArray(result.findings));
+    assert.ok(Array.isArray(result.warnings));
+  });
+
+  await test('checkControlEventHeavySession returns { findings, warnings }', async () => {
+    const result = checkControlEventHeavySession([]);
+    assert.ok(Array.isArray(result.findings));
+    assert.ok(Array.isArray(result.warnings));
+  });
+
+  await test('checkExcessiveToolActivity returns { findings, warnings }', async () => {
+    const result = checkExcessiveToolActivity([]);
+    assert.ok(Array.isArray(result.findings));
+    assert.ok(Array.isArray(result.warnings));
+  });
+
+  // ── 9. Regression: prior validators unaffected ───────────────────────────
+
+  console.log('\n9. Regression — prior validators unaffected');
+
+  await test('completeness validator still works correctly', async () => {
+    const { validate: validateCompleteness } = require('../src/detection/event-completeness-validator');
+    const result = validateCompleteness([]);
+    assert.strictEqual(result.complete, true);
+    assert.ok(Array.isArray(result.issues));
+  });
+
+  await test('correlation integrity validator still works correctly', async () => {
+    const { validate: validateIntegrity } = require('../src/detection/correlation-integrity-validator');
+    const result = validateIntegrity([]);
+    assert.strictEqual(result.valid, true);
+    assert.ok(Array.isArray(result.issues));
+  });
+
+  // ── Summary ───────────────────────────────────────────────────────────────
+
+  const bar = '─'.repeat(40);
+  console.log(`\n${bar}`);
+  console.log(`Results: ${passed} passed, ${failed} failed`);
+  if (failed > 0) process.exit(1);
+
+})().catch(err => {
+  console.error('\nValidation script crashed:', err.message);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- Introduces `src/detection/session-anomaly-detector.js` — a pure, rule-based detector that evaluates a session trace for suspicious behavioral patterns
- Third detection layer alongside completeness (TD-HMCP-000003) and integrity (TD-HMCP-000004); uses `anomalous: boolean` to distinguish from `complete` and `valid`
- Five rules: repeated denials, approval without follow-through, conflicting control outcomes, control-event-heavy sessions, excessive tool activity
- Exports `FINDING_CODES` and `THRESHOLDS` constants; individual rule functions for targeted testing
- 39 tests; all prior test suites pass without modification

## Changes

- `src/detection/session-anomaly-detector.js` — five-rule detector; `detect()` entry point; `FINDING_CODES` and `THRESHOLDS` constants; exported rule functions
- `tests/validate-session-anomaly-detection.js` — 39 tests across 9 groups including threshold boundary tests and regression checks for prior validators
- `docs/detection/session-anomaly-detection.md` — full documentation: rules, result shape, finding codes, thresholds, relationship to completeness/integrity validators, future extension points

## Test plan

- [x] `node tests/validate-session-anomaly-detection.js` — 39 passed, 0 failed
- [x] `node tests/validate-event-completeness.js` — 33 passed, 0 failed (regression)
- [x] `node tests/validate-correlation-integrity.js` — 38 passed, 0 failed (regression)
- [x] `node tests/validate-approval-gate.js` — 24 passed, 0 failed (regression)
- [x] `node tests/validate-policy-gate.js` — 21 passed, 0 failed (regression)

Implements: CC-HMCP-000014 / TD-HMCP-000001

🤖 Generated with [Claude Code](https://claude.com/claude-code)